### PR TITLE
Final changes for 0.1.0 release.

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,1 @@
+include lib/kastore.h

--- a/python/README.rst
+++ b/python/README.rst
@@ -2,3 +2,6 @@ kastore
 =======
 
 A simple write-once-read-many store for numerical data.
+
+This package is under active development, and is not recommended for
+general use.

--- a/python/kastore/__init__.py
+++ b/python/kastore/__init__.py
@@ -1,12 +1,7 @@
 from __future__ import print_function
 from __future__ import division
 
-__version__ = "undefined"
-try:
-    from . import _version
-    __version__ = _version.version
-except ImportError:
-    pass
+__version__ = "0.1.0"
 
 from . import store
 from . exceptions import FileFormatError

--- a/python/setup.py
+++ b/python/setup.py
@@ -40,6 +40,7 @@ setup(
     long_description=long_description,
     url='https://github.com/tskit-dev/kastore',
     author='tskit developers',
+    version='0.1.0',
     # TODO setup a tskit developers email address.
     author_email='jerome.kelleher@well.ox.ac.uk',
     classifiers=[
@@ -67,8 +68,5 @@ setup(
         'Bug Reports': 'https://github.com/tskit-dev/kastore/issues',
         'Source': 'https://github.com/tskit-dev/kastore',
     },
-    setup_requires=['numpy', 'setuptools_scm'],
-    use_scm_version={
-        "root": "..", "relative_to": __file__,
-        "write_to": "python/kastore/_version.py"},
+    setup_requires=['numpy'],
 )


### PR DESCRIPTION
Removed setuptools_scm as the non standard directory layout was causing
problems. Some other strategy will likely be required for versioning in
any case for the C API, so it's probably not appropriate here.