### PR TITLE
Ditch mmap

### DIFF
--- a/c/kastore.h
+++ b/c/kastore.h
@@ -82,7 +82,7 @@ The requested type does not match the type of the stored values.
 /** @} */
 
 /* Flags for open */
-#define KAS_NO_MMAP             1
+#define KAS_READ_ALL            1
 
 
 /**

--- a/c/malloc_tests.c
+++ b/c/malloc_tests.c
@@ -141,7 +141,7 @@ test_open_read(void)
     const char *filename = "test-data/v1/all_types_1_elements.kas";
     bool done;
     size_t f;
-    int flags[] = {0, KAS_NO_MMAP};
+    int flags[] = {0, KAS_READ_ALL};
 
     /* Make sure the failing malloc setup works first */
     _malloc_fail_at = 0;
@@ -187,7 +187,7 @@ test_read(void)
     /* Make sure the failing malloc setup works first */
     _malloc_fail_at = 0;
     _malloc_count = 0;
-    ret = kastore_open(&store, filename, "r", KAS_NO_MMAP);
+    ret = kastore_open(&store, filename, "r", KAS_READ_ALL);
     CU_ASSERT_EQUAL_FATAL(ret, KAS_ERR_NO_MEMORY);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);

--- a/c/meson.build
+++ b/c/meson.build
@@ -18,9 +18,7 @@ executable('io_tests', ['io_tests.c', 'kastore.c'],
         '-Wl,--wrap=fwrite', 
         '-Wl,--wrap=fread', 
         '-Wl,--wrap=fclose',
-        '-Wl,--wrap=fseek',
-        '-Wl,--wrap=stat64',
-        '-Wl,--wrap=mmap64'])
+        '-Wl,--wrap=fseek'])
 
 shared_library('kastore', 'kastore.c')
  

--- a/c/tests.c
+++ b/c/tests.c
@@ -968,7 +968,7 @@ verify_bad_file(const char *filename, int err)
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
-    ret = kastore_open(&store, filename, "r", KAS_NO_MMAP);
+    ret = kastore_open(&store, filename, "r", KAS_READ_ALL);
     CU_ASSERT_EQUAL_FATAL(ret, err);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);

--- a/python/_kastoremodule.c
+++ b/python/_kastoremodule.c
@@ -140,14 +140,25 @@ build_dictionary(kastore_t *store)
     PyObject *data = PyDict_New();
     kaitem_t *item;
     npy_intp dims;
-    int dtype;
-    size_t j;
+    int dtype, dummy_type, err;
+    size_t j, dummy_len;
+    void *dummy_array;
 
     if (data == NULL) {
         goto out;
     }
     for (j = 0; j < store->num_items; j++) {
         item = store->items + j;
+        /* When we're opened in the default mode, the item array pointers
+         * aren't set until after 'get' is called. So, we have to kludge
+         * around this until we have a proper API for accessing all items
+         */
+        err = kastore_get(store, item->key, item->key_len, &dummy_array,
+                &dummy_len, &dummy_type);
+        if (err != 0) {
+            handle_library_error(err);
+            goto out;
+        }
         key = PyUnicode_FromStringAndSize(item->key, item->key_len);
         if (key == NULL) {
             goto out;
@@ -240,7 +251,7 @@ kastore_load(PyObject *self, PyObject *args, PyObject *kwds)
     PyObject *data = NULL;
     static char *kwlist[] = {"filename", "use_mmap", NULL};
     int use_mmap = 1;
-    int flags;
+    int flags = 0;
 
     memset(&store, 0, sizeof(store));
 
@@ -248,8 +259,9 @@ kastore_load(PyObject *self, PyObject *args, PyObject *kwds)
                 &filename, &use_mmap)) {
         goto out;
     }
+    flags = 0;
     if (! use_mmap) {
-        flags = KAS_NO_MMAP;
+        flags = KAS_READ_ALL;
     }
     err = kastore_open(&store, filename, "r", flags);
     if (err != 0) {

--- a/python/_kastoremodule.c
+++ b/python/_kastoremodule.c
@@ -249,18 +249,17 @@ kastore_load(PyObject *self, PyObject *args, PyObject *kwds)
     char *filename;
     kastore_t store;
     PyObject *data = NULL;
-    static char *kwlist[] = {"filename", "use_mmap", NULL};
-    int use_mmap = 1;
+    static char *kwlist[] = {"filename", "read_all", NULL};
+    int read_all = 0;
     int flags = 0;
 
     memset(&store, 0, sizeof(store));
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|i:load", kwlist,
-                &filename, &use_mmap)) {
+                &filename, &read_all)) {
         goto out;
     }
-    flags = 0;
-    if (! use_mmap) {
+    if (read_all) {
         flags = KAS_READ_ALL;
     }
     err = kastore_open(&store, filename, "r", flags);

--- a/python/kastore/__init__.py
+++ b/python/kastore/__init__.py
@@ -35,10 +35,13 @@ def _raise_unknown_engine():
     raise ValueError("unknown engine")
 
 
-def load(filename, use_mmap=True, key_encoding="utf-8", engine=PY_ENGINE):
+def load(filename, read_all=False, key_encoding="utf-8", engine=PY_ENGINE):
     """
     Loads a store from the specified file.
 
+    :param bool read_all: If True, read the entire file into memory. This
+        optimisation is useful when all the data will be needed, saving some
+        malloc and fread overhead.
     :param str filename: The path of the file to load.
     :param str key_encoding: The encoding to use when converting the keys from
         raw bytes.
@@ -46,11 +49,11 @@ def load(filename, use_mmap=True, key_encoding="utf-8", engine=PY_ENGINE):
     :return: A dict-like object mapping the key-array pairs.
     """
     if engine == PY_ENGINE:
-        return store.load(filename, use_mmap=use_mmap, key_encoding=key_encoding)
+        return store.load(filename, read_all=read_all, key_encoding=key_encoding)
     elif engine == C_ENGINE:
         _check_low_level_module()
         try:
-            return _kastore.load(filename, use_mmap=use_mmap)
+            return _kastore.load(filename, read_all=read_all)
         except _kastore.FileFormatError as e:
             # Note in Python 3 we should use "raise X from e" to designate
             # that the low-level exception is the cause of the high-level

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -172,9 +172,8 @@ class MalformedFilesMixin(FileFormatsMixin):
                 self.assertEqual(len(buff), before_len)
                 with open(self.temp_file, 'wb') as f:
                     f.write(buff)
-                self.assertRaises(
-                    kas.FileFormatError, kas.load, self.temp_file, engine=self.engine,
-                    use_mmap=self.use_mmap)
+                with self.assertRaises(kas.FileFormatError):
+                    kas.load(self.temp_file, engine=self.engine, use_mmap=self.use_mmap)
 
     def test_bad_item_types(self):
         items = {"a": []}
@@ -184,9 +183,8 @@ class MalformedFilesMixin(FileFormatsMixin):
             with open(self.temp_file, "wb") as f:
                 descriptors[0].type = bad_type
                 store.write_file(f, descriptors, file_size)
-            self.assertRaises(
-                kas.FileFormatError, kas.load, self.temp_file, engine=self.engine,
-                use_mmap=self.use_mmap)
+            with self.assertRaises(kas.FileFormatError):
+                kas.load(self.temp_file, engine=self.engine, use_mmap=self.use_mmap)
 
     def test_bad_key_initial_offsets(self):
         items = {"a": np.arange(100)}

--- a/python/tests/test_errors.py
+++ b/python/tests/test_errors.py
@@ -145,7 +145,7 @@ class MalformedFilesMixin(FileFormatsMixin):
         self.assertEqual(os.path.getsize(self.temp_file), 0)
         self.assertRaises(
             kas.FileFormatError, kas.load, self.temp_file, engine=self.engine,
-            use_mmap=self.use_mmap)
+            read_all=self.read_all)
 
     def test_bad_magic(self):
         self.write_file()
@@ -158,7 +158,7 @@ class MalformedFilesMixin(FileFormatsMixin):
             f.write(buff)
         self.assertRaises(
             kas.FileFormatError, kas.load, self.temp_file, engine=self.engine,
-            use_mmap=self.use_mmap)
+            read_all=self.read_all)
 
     def test_bad_file_size(self):
         for num_items in range(10):
@@ -173,7 +173,7 @@ class MalformedFilesMixin(FileFormatsMixin):
                 with open(self.temp_file, 'wb') as f:
                     f.write(buff)
                 with self.assertRaises(kas.FileFormatError):
-                    kas.load(self.temp_file, engine=self.engine, use_mmap=self.use_mmap)
+                    kas.load(self.temp_file, engine=self.engine, read_all=self.read_all)
 
     def test_bad_item_types(self):
         items = {"a": []}
@@ -184,7 +184,7 @@ class MalformedFilesMixin(FileFormatsMixin):
                 descriptors[0].type = bad_type
                 store.write_file(f, descriptors, file_size)
             with self.assertRaises(kas.FileFormatError):
-                kas.load(self.temp_file, engine=self.engine, use_mmap=self.use_mmap)
+                kas.load(self.temp_file, engine=self.engine, read_all=self.read_all)
 
     def test_bad_key_initial_offsets(self):
         items = {"a": np.arange(100)}
@@ -197,7 +197,7 @@ class MalformedFilesMixin(FileFormatsMixin):
                 store.write_file(f, descriptors, file_size)
             self.assertRaises(
                 kas.FileFormatError, kas.load, self.temp_file, engine=self.engine,
-                use_mmap=self.use_mmap)
+                read_all=self.read_all)
 
     def test_bad_key_non_sequential(self):
         items = {"a": np.arange(100), "b": []}
@@ -207,7 +207,7 @@ class MalformedFilesMixin(FileFormatsMixin):
             descriptors[1].key_start += offset
             self.assertRaises(
                 kas.FileFormatError, kas.load, self.temp_file, engine=self.engine,
-                use_mmap=self.use_mmap)
+                read_all=self.read_all)
 
     def test_bad_array_initial_offset(self):
         items = {"a": np.arange(100)}
@@ -219,7 +219,7 @@ class MalformedFilesMixin(FileFormatsMixin):
                 store.write_file(f, descriptors, file_size)
             self.assertRaises(
                 kas.FileFormatError, kas.load, self.temp_file, engine=self.engine,
-                use_mmap=self.use_mmap)
+                read_all=self.read_all)
 
     def test_bad_array_non_sequential(self):
         items = {"a": np.arange(100), "b": []}
@@ -230,26 +230,26 @@ class MalformedFilesMixin(FileFormatsMixin):
                 store.write_file(f, descriptors, file_size)
             self.assertRaises(
                 kas.FileFormatError, kas.load, self.temp_file, engine=self.engine,
-                use_mmap=self.use_mmap)
+                read_all=self.read_all)
 
 
 class TestMalformedFilesPyEngine(MalformedFilesMixin, unittest.TestCase):
-    use_mmap = True
+    read_all = False
     engine = kas.PY_ENGINE
 
 
 class TestMalformedFilesCEngine(MalformedFilesMixin, unittest.TestCase):
-    use_mmap = True
+    read_all = False
     engine = kas.C_ENGINE
 
 
-class TestMalformedFilesPyEngineNoMmap(MalformedFilesMixin, unittest.TestCase):
-    use_mmap = False
+class TestMalformedFilesPyEngineReadAll(MalformedFilesMixin, unittest.TestCase):
+    read_all = True
     engine = kas.PY_ENGINE
 
 
-class TestMalformedFilesCEngineNoMmap(MalformedFilesMixin, unittest.TestCase):
-    use_mmap = False
+class TestMalformedFilesCEngineReadAll(MalformedFilesMixin, unittest.TestCase):
+    read_all = True
     engine = kas.C_ENGINE
 
 
@@ -266,7 +266,7 @@ class FileVersionsMixin(FileFormatsMixin):
         self.assertEqual(len(buff), before_len)
         with open(self.temp_file, 'wb') as f:
             f.write(buff)
-        kas.load(self.temp_file, engine=self.engine, use_mmap=self.use_mmap)
+        kas.load(self.temp_file, engine=self.engine, read_all=self.read_all)
 
     def test_major_version_too_old(self):
         self.assertRaises(
@@ -281,19 +281,19 @@ class FileVersionsMixin(FileFormatsMixin):
 
 class TestFileVersionsPyEngine(FileVersionsMixin, unittest.TestCase):
     engine = kas.PY_ENGINE
-    use_mmap = True
+    read_all = False
 
 
-class TestFileVersionsPyEngineNoMmap(FileVersionsMixin, unittest.TestCase):
+class TestFileVersionsPyEngineReadAll(FileVersionsMixin, unittest.TestCase):
     engine = kas.PY_ENGINE
-    use_mmap = False
+    read_all = True
 
 
 class TestFileVersionsCEngine(FileVersionsMixin, unittest.TestCase):
     engine = kas.C_ENGINE
-    use_mmap = True
+    read_all = False
 
 
-class TestFileVersionsCEngineNoMmap(FileVersionsMixin, unittest.TestCase):
+class TestFileVersionsCEngineReadAll(FileVersionsMixin, unittest.TestCase):
     engine = kas.C_ENGINE
-    use_mmap = False
+    read_all = True

--- a/python/tests/test_interface.py
+++ b/python/tests/test_interface.py
@@ -39,8 +39,8 @@ class TestBasicInfo(InterfaceTest):
 
     def verify(self, data):
         kas.dump(data, self.temp_file)
-        for use_mmap in [True, False]:
-            new_data = kas.load(self.temp_file, use_mmap=use_mmap)
+        for read_all in [True, False]:
+            new_data = kas.load(self.temp_file, read_all=read_all)
             for key, array in new_data.items():
                 info = new_data.info(key)
                 s = str(info)

--- a/python/tests/test_standard_files.py
+++ b/python/tests/test_standard_files.py
@@ -28,7 +28,7 @@ class StandardFilesMixin(object):
 
     def read_file(self, filename):
         full_path = os.path.join(self.test_data_path, filename)
-        return kas.load(full_path, engine=self.engine, use_mmap=False)
+        return kas.load(full_path, engine=self.engine, read_all=False)
 
     def test_empty_file(self):
         self.assertRaises(
@@ -130,19 +130,19 @@ class StandardFilesMixin(object):
 
 class TestStandardFilesPyEngine(StandardFilesMixin, unittest.TestCase):
     engine = kas.PY_ENGINE
-    use_mmap = True
+    read_all = False
 
 
 class TestStandardFilesCEngine(StandardFilesMixin, unittest.TestCase):
     engine = kas.C_ENGINE
-    use_mmap = True
+    read_all = False
 
 
-class TestStandardFilesPyEngineNoMmap(StandardFilesMixin, unittest.TestCase):
+class TestStandardFilesPyEngineReadAll(StandardFilesMixin, unittest.TestCase):
     engine = kas.PY_ENGINE
-    use_mmap = False
+    read_all = True
 
 
-class TestStandardFilesCEngineNoMmap(StandardFilesMixin, unittest.TestCase):
+class TestStandardFilesCEngineReadAll(StandardFilesMixin, unittest.TestCase):
     engine = kas.C_ENGINE
-    use_mmap = False
+    read_all = True

--- a/python/tests/test_storage.py
+++ b/python/tests/test_storage.py
@@ -60,9 +60,9 @@ class TestRoundTrip(unittest.TestCase):
 
     def verify(self, data):
         for engine in [kas.C_ENGINE, kas.PY_ENGINE]:
-            for use_mmap in [True, False]:
+            for read_all in [True, False]:
                 kas.dump(data, self.temp_file, engine=engine)
-                new_data = kas.load(self.temp_file, use_mmap=use_mmap, engine=engine)
+                new_data = kas.load(self.temp_file, read_all=read_all, engine=engine)
                 self.assertEqual(sorted(new_data.keys()), sorted(data.keys()))
                 for key, source_array in data.items():
                     dest_array = new_data[key]


### PR DESCRIPTION
Removes the ``no_mmap`` flag from open, replacing with ``read_all``.

The Python implementation still uses mmap under the hood and is still vulnerable to bus errors when the underlying file is truncated. We can resolve this problem later; this PR is concerned with stabilising the long-term API.