### PR TITLE
Minimal changes to enable meson subproject.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,18 @@ jobs:
             ./build-clang/io_tests
 
       - run:
+          name: Install shared library
+          command: |
+            meson build-install c --prefix=/usr
+            sudo ninja -C build-install install
+
+     - run:
+          name: Hand-compile a program.
+          command: |
+            g++ c/cpp_tests.cpp -o cpp_tests -lkastore
+            ./cpp_tests
+
+      - run:
           name: Build docs
           command: |
             cd docs && make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ jobs:
           command: |
             pip install --user -r python/requirements/development.txt
             sudo apt-get install ninja-build libcunit1-dev valgrind clang doxygen
-            pip install meson --user
+            # Install meson as root so we can install to the system below.
+            sudo pip install meson 
             echo 'export PATH=/home/circleci/.local/bin:$PATH' >> $BASH_ENV
       - run:
           name: Compile Python
@@ -92,7 +93,7 @@ jobs:
             meson build-install c --prefix=/usr
             sudo ninja -C build-install install
 
-     - run:
+      - run:
           name: Hand-compile a program.
           command: |
             g++ c/cpp_tests.cpp -o cpp_tests -lkastore

--- a/c/meson.build
+++ b/c/meson.build
@@ -1,28 +1,38 @@
-project('kastore', ['c', 'cpp'])
-add_global_arguments([
-    '-std=c99', '-Wall', '-Wextra', '-Werror', '-Wpedantic', '-W',
-    '-Wmissing-prototypes',  '-Wstrict-prototypes',
-    '-Wconversion', '-Wshadow', '-Wpointer-arith', '-Wcast-align',
-    '-Wcast-qual', '-Wwrite-strings', '-Wnested-externs',
-    '-fshort-enums', '-fno-common'], language : 'c')
+project('kastore', ['c', 'cpp'], default_options: ['c_std=c99', 'cpp_std=c++11'])
 
-shared_library('kastore', 'kastore.c')
-static_lib = static_library('kastore', 'kastore.c')
+if not meson.is_subproject()
+    add_global_arguments([
+        '-Wall', '-Wextra', '-Werror', '-Wpedantic', '-W',
+        '-Wmissing-prototypes',  '-Wstrict-prototypes',
+        '-Wconversion', '-Wshadow', '-Wpointer-arith', '-Wcast-align',
+        '-Wcast-qual', '-Wwrite-strings', '-Wnested-externs',
+        '-fshort-enums', '-fno-common'], language : 'c')
+endif
 
-cunit_dep = dependency('cunit')
-executable('tests', ['tests.c', 'kastore.c'], dependencies: cunit_dep)
+# Subprojects should compile in the static library for simplicity.
+inc = include_directories('.')
+kastore = static_library('kastore', 'kastore.c')
+kastore_dep = declare_dependency(link_with : kastore, include_directories: inc)
 
-executable('cpp_tests', ['cpp_tests.cpp'], link_with: static_lib)
+# The shared library can be installed into the system.
+install_headers('kastore.h')
+shared_library('kastore', 'kastore.c', install: true)
 
-executable('malloc_tests', ['malloc_tests.c', 'kastore.c'], 
-    dependencies: cunit_dep, 
-    link_args:['-Wl,--wrap=malloc', '-Wl,--wrap=realloc', '-Wl,--wrap=calloc'])
+if not meson.is_subproject()
+    cunit_dep = dependency('cunit')
+    executable('tests', ['tests.c', 'kastore.c'], dependencies: cunit_dep)
 
-executable('io_tests', ['io_tests.c', 'kastore.c'], 
-    dependencies: cunit_dep, 
-    link_args:[
-        '-Wl,--wrap=fwrite', 
-        '-Wl,--wrap=fread', 
-        '-Wl,--wrap=fclose',
-        '-Wl,--wrap=fseek'])
+    executable('cpp_tests', ['cpp_tests.cpp'], link_with: kastore)
 
+    executable('malloc_tests', ['malloc_tests.c', 'kastore.c'], 
+        dependencies: cunit_dep, 
+        link_args:['-Wl,--wrap=malloc', '-Wl,--wrap=realloc', '-Wl,--wrap=calloc'])
+
+    executable('io_tests', ['io_tests.c', 'kastore.c'], 
+        dependencies: cunit_dep, 
+        link_args:[
+            '-Wl,--wrap=fwrite', 
+            '-Wl,--wrap=fread', 
+            '-Wl,--wrap=fclose',
+            '-Wl,--wrap=fseek'])
+endif

--- a/python/tests/test_file_format.py
+++ b/python/tests/test_file_format.py
@@ -18,6 +18,9 @@ import hypothesis.strategies as hst
 import kastore as kas
 import kastore.store as store
 
+# Set the deadline to None to avoid weird behaviour on CI.
+hypothesis.settings.register_profile("kastore_defaults", deadline=None)
+hypothesis.settings.load_profile("kastore_defaults")
 
 # Exclude any 'other' unicode categories:
 # http://www.unicode.org/reports/tr44/#General_Category_Values


### PR DESCRIPTION
Not working yet. Ideally we would like to declare kastore as a [subproject]( mesonbuild.com/Subprojects.html) to simplify tskit and allow us to provide a good example of how to set up a project with tskit using [wrap](mesonbuild.com/Wrap-dependency-system-manual.html).