### PR TITLE
pass buffer for write without copy

### DIFF
--- a/c/kastore.c
+++ b/c/kastore.c
@@ -728,7 +728,7 @@ kastore_gets_float64(kastore_t *self, const char *key, double **array, size_t *a
 int KAS_WARN_UNUSED
 kastore_put(kastore_t *self, const char *key, size_t key_len,
        const void *array, size_t array_len, int type,
-       int KAS_UNUSED(flags))
+       int flags)
 {
     int ret = 0;
     kaitem_t *new_item;
@@ -763,7 +763,9 @@ kastore_put(kastore_t *self, const char *key, size_t key_len,
     new_item->array_len = array_len;
     array_size = type_size(type) * array_len;
     new_item->key = malloc(key_len);
-    new_item->array = malloc(array_size == 0? 1: array_size);
+    // Note we cast away const here on array because we take ownership, so now array is ours and we can modify it if we like
+    // This is not optimal (probably violates the standard); the alternative is to make the parameter array be non-const, I guess
+    new_item->array = (flags & KAS_TAKE_BUFFER) ? (void *)array : malloc(array_size == 0 ? 1 : array_size);
     if (new_item->key == NULL || new_item->array == NULL) {
         kas_safe_free(new_item->key);
         kas_safe_free(new_item->array);
@@ -772,7 +774,9 @@ kastore_put(kastore_t *self, const char *key, size_t key_len,
     }
     self->num_items++;
     memcpy(new_item->key, key, key_len);
-    memcpy(new_item->array, array, array_size);
+    if ((flags & KAS_TAKE_BUFFER) == 0) {
+        memcpy(new_item->array, array, array_size);
+    }
 
     /* Check if this key is already in here. OK, this is a quadratic time
      * algorithm, but we're not expecting to have lots of items (< 100). In

--- a/c/kastore.h
+++ b/c/kastore.h
@@ -107,6 +107,9 @@ The requested type does not match the type of the stored values.
 
 #define KAS_NUM_TYPES           10
 
+/* Flags for the kastore_put* family of functions */
+#define KAS_TAKE_BUFFER			1
+
 #define KAS_READ                1
 #define KAS_WRITE               2
 


### PR DESCRIPTION
@bhaller has asked me to pass along the following addition to `kastore_put`, that defines a new flag, `KASTORE_TAKE_BUFFER` to the `kastore_put( )` function, that allows a pointer to an array to be copied into a kastore without copying it. This needs some tests and whatnot, if it's a good idea, obviously.