### PR TITLE
Memory leak

### DIFF
--- a/python/_kastoremodule.c
+++ b/python/_kastoremodule.c
@@ -167,6 +167,8 @@ build_dictionary(kastore_t *store)
         if (PyDict_SetItem(data, key, (PyObject *) array) != 0) {
             goto out;
         }
+        Py_XDECREF(key);
+        Py_XDECREF(array);
         key = NULL;
         array = NULL;
     }


### PR DESCRIPTION
Fixes #93.

[PyDict_SetItem](https://docs.python.org/3/c-api/dict.html#c.PyDict_SetItem) does not steal a reference to *val* (`array` here), so we need to `Py_XDECREF(array)`. The docs don't mention anything about the reference to *key*, but the `Py_XDECREF(key)` makes the remaining leaks disappear.