### PR TITLE
Require python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
     - os: linux
       python: 3.6
     - os: linux
+      python: 3.7
+    - os: linux
       python: 3.8
     - os: osx
       language: generic

--- a/python/setup.py
+++ b/python/setup.py
@@ -48,16 +48,16 @@ setup(
     version=kastore_version,
     # TODO setup a tskit developers email address.
     author_email="jerome.kelleher@well.ox.ac.uk",
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3 :: Only",
     ],
     keywords="Binary store numerical arrays",


### PR DESCRIPTION
Fixes #103 
I've added 3.7 to travis too, as although it's in appveyor the travis builds happen in parallel so there's no harm.