### PR TITLE
Format C code with clang-format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,20 @@ on:
     branches: [master]
 
 jobs:
+  lint-c:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+      - name: install clang-format
+        run: |
+          sudo apt-get remove -y clang-6.0 libclang-common-6.0-dev libclang1-6.0 libllvm6.0
+          sudo apt-get autoremove
+          sudo apt-get install clang-format clang-format-6.0
+      - name: install run-clang-format
+        run: wget https://raw.githubusercontent.com/Sarcasm/run-clang-format/de6e8ca07d171a7f378d379ff252a00f2905e81d/run-clang-format.py
+      - name: clang-format
+        run: python run-clang-format.py --clang-format-executable=clang-format -r c
   pre-commit:
     runs-on: ubuntu-18.04
     steps:

--- a/c/.clang-format
+++ b/c/.clang-format
@@ -1,0 +1,21 @@
+Language: Cpp
+BasedOnStyle: GNU
+SortIncludes:    false
+AllowShortIfStatementsOnASingleLine: false
+BreakBeforeBraces: Linux
+TabWidth:        4
+IndentWidth:     4
+ColumnLimit:     89
+SpaceBeforeParens:
+    ControlStatements
+SpacesInCStyleCastParentheses: false
+SpaceAfterCStyleCast: true
+IndentCaseLabels: true
+AlignAfterOpenBracket: DontAlign
+BinPackArguments: true
+BinPackParameters: true
+AlwaysBreakAfterReturnType: AllDefinitions
+
+# These are disabled for version 6 compatibility
+# StatementMacros: ["PyObject_HEAD"]
+# AlignConsecutiveMacros: true

--- a/c/cpp_tests.cpp
+++ b/c/cpp_tests.cpp
@@ -28,7 +28,8 @@ test_open_error()
     kastore_close(&store);
 }
 
-int main()
+int
+main()
 {
     test_open_error();
     test_strerror();

--- a/c/example.c
+++ b/c/example.c
@@ -11,7 +11,7 @@
 static void
 handle_kas_error(int line, int retval)
 {
-   errx(1, "Error at line %d: %s", line, kas_strerror(retval));
+    errx(1, "Error at line %d: %s", line, kas_strerror(retval));
 }
 
 static void
@@ -19,7 +19,7 @@ write_example(const char *path)
 {
     int ret;
     kastore_t store;
-    const uint32_t a[] = {1, 2, 3, 4};
+    const uint32_t a[] = { 1, 2, 3, 4 };
     size_t b_length = 10;
     uint32_t *b = calloc(b_length, sizeof(*b));
 
@@ -62,7 +62,7 @@ read_example(const char *path)
     kastore_t store;
     uint32_t *array;
     size_t j, k, array_len;
-    const char *keys[] = {"a", "b"};
+    const char *keys[] = { "a", "b" };
 
     ret = kastore_open(&store, path, "r", 0);
     if (ret != 0) {
@@ -75,7 +75,7 @@ read_example(const char *path)
         }
         printf("key: %s = [", keys[j]);
         for (k = 0; k < array_len; k++) {
-            printf("%d%s", array[k], k == array_len - 1 ? "]\n": ", ");
+            printf("%d%s", array[k], k == array_len - 1 ? "]\n" : ", ");
         }
     }
     ret = kastore_close(&store);

--- a/c/io_tests.c
+++ b/c/io_tests.c
@@ -12,7 +12,7 @@
 #include "kastore.h"
 #include <CUnit/Basic.h>
 
-char * _tmp_file_name;
+char *_tmp_file_name;
 
 /* Wrappers used to check for correct error handling. Must be linked with the
  * link option, e.g., -Wl,--wrap=fwrite. See 'ld' manpage for details.
@@ -105,7 +105,7 @@ test_write_empty(void)
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, KAS_ERR_IO);
 
-   /* Make sure we reset this for other functions */
+    /* Make sure we reset this for other functions */
     _fwrite_fail_at = -1;
 }
 
@@ -114,7 +114,7 @@ test_write(void)
 {
     kastore_t store;
     int ret = 0;
-    int8_t array[] = {1};
+    int8_t array[] = { 1 };
     bool done;
 
     /* keep increasing fail_at until we pass. This should catch all possible
@@ -122,7 +122,7 @@ test_write(void)
     _fwrite_fail_at = 0;
     _fwrite_count = 0;
     done = false;
-    while (! done) {
+    while (!done) {
         ret = kastore_open(&store, _tmp_file_name, "w", 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         _fwrite_count = 0;
@@ -146,7 +146,7 @@ test_write_fclose(void)
 {
     kastore_t store;
     int ret = 0;
-    int8_t array[] = {1};
+    int8_t array[] = { 1 };
     bool done;
 
     /* keep increasing fail_at until we pass. This should catch all possible
@@ -154,7 +154,7 @@ test_write_fclose(void)
     _fclose_fail_at = 0;
     _fclose_count = 0;
     done = false;
-    while (! done) {
+    while (!done) {
         ret = kastore_open(&store, _tmp_file_name, "w", 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         _fclose_count = 0;
@@ -187,7 +187,7 @@ test_read_fclose(void)
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, KAS_ERR_IO);
 
-   _fclose_fail_at = -1;
+    _fclose_fail_at = -1;
 }
 
 static void
@@ -195,10 +195,10 @@ test_append_fclose(void)
 {
     kastore_t store;
     int ret = 0;
-    int8_t array[] = {1};
+    int8_t array[] = { 1 };
     bool done;
     size_t index = 0;
-    const char * keys[] = {"b", "c"};
+    const char *keys[] = { "b", "c" };
 
     ret = kastore_open(&store, _tmp_file_name, "w", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -212,7 +212,7 @@ test_append_fclose(void)
     _fclose_fail_at = 0;
     _fclose_count = 0;
     done = false;
-    while (! done) {
+    while (!done) {
         ret = kastore_open(&store, _tmp_file_name, "a", 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         _fclose_count = 0;
@@ -241,7 +241,7 @@ test_open_read_fread(void)
     const char *filename = "test-data/v1/all_types_1_elements.kas";
     bool done;
     size_t f;
-    int flags[] = {0, KAS_READ_ALL};
+    int flags[] = { 0, KAS_READ_ALL };
 
     _fread_fail_at = 0;
     /* Make sure the failing fread setup works first */
@@ -265,7 +265,7 @@ test_open_read_fread(void)
     for (f = 0; f < sizeof(flags) / sizeof(*flags); f++) {
         _fread_fail_at = 0;
         done = false;
-        while (! done) {
+        while (!done) {
             _fread_count = 0;
             ret = kastore_open(&store, filename, "r", flags[f]);
             if (ret == 0) {
@@ -380,8 +380,7 @@ kastore_suite_cleanup(void)
 static void
 handle_cunit_error(void)
 {
-    fprintf(stderr, "CUnit error occured: %d: %s\n",
-            CU_get_error(), CU_get_error_msg());
+    fprintf(stderr, "CUnit error occured: %d: %s\n", CU_get_error(), CU_get_error_msg());
     exit(EXIT_FAILURE);
 }
 
@@ -392,27 +391,25 @@ main(int argc, char **argv)
     CU_pTest test;
     CU_pSuite suite;
     CU_TestInfo tests[] = {
-        {"test_write_empty", test_write_empty},
-        {"test_write", test_write},
-        {"test_write_fclose", test_write_fclose},
-        {"test_read_fclose", test_read_fclose},
-        {"test_append_fclose", test_append_fclose},
-        {"test_open_read_fread", test_open_read_fread},
-        {"test_get_fseek", test_get_fseek},
-        {"test_get_ftell", test_get_ftell},
-        {"test_get_fread", test_get_fread},
+        { "test_write_empty", test_write_empty },
+        { "test_write", test_write },
+        { "test_write_fclose", test_write_fclose },
+        { "test_read_fclose", test_read_fclose },
+        { "test_append_fclose", test_append_fclose },
+        { "test_open_read_fread", test_open_read_fread },
+        { "test_get_fseek", test_get_fseek },
+        { "test_get_ftell", test_get_ftell },
+        { "test_get_fread", test_get_fread },
         CU_TEST_INFO_NULL,
     };
 
     /* We use initialisers here as the struct definitions change between
      * versions of CUnit */
     CU_SuiteInfo suites[] = {
-        {
-            .pName = "kastore",
+        { .pName = "kastore",
             .pInitFunc = kastore_suite_init,
             .pCleanupFunc = kastore_suite_cleanup,
-            .pTests = tests
-        },
+            .pTests = tests },
         CU_SUITE_INFO_NULL,
     };
     if (CUE_SUCCESS != CU_initialize_registry()) {

--- a/c/kastore.c
+++ b/c/kastore.c
@@ -9,8 +9,7 @@
 
 /* Private flag used to indicate when we have opened the file ourselves
  * and need to free it. */
-#define OWN_FILE  (1 << 31)
-
+#define OWN_FILE (1 << 31)
 
 const char *
 kas_strerror(int err)
@@ -24,7 +23,7 @@ kas_strerror(int err)
         case KAS_ERR_IO:
             if (errno != 0) {
                 ret = strerror(errno);
-            }  else {
+            } else {
                 ret = "I/O error with errno unset. Please file a bug report";
             }
             break;
@@ -42,11 +41,11 @@ kas_strerror(int err)
             break;
         case KAS_ERR_VERSION_TOO_OLD:
             ret = "File format version is too old. Please upgrade using "
-                "'kas upgrade <filename>'";
+                  "'kas upgrade <filename>'";
             break;
         case KAS_ERR_VERSION_TOO_NEW:
             ret = "File format version is too new. Please upgrade your "
-                "kastore library version";
+                  "kastore library version";
             break;
         case KAS_ERR_BAD_TYPE:
             ret = "Unknown data type";
@@ -87,17 +86,18 @@ kas_version(void)
 static size_t
 type_size(int type)
 {
-    const size_t type_size_map[] = {1, 1, 2, 2, 4, 4, 8, 8, 4, 8};
+    const size_t type_size_map[] = { 1, 1, 2, 2, 4, 4, 8, 8, 4, 8 };
     assert(type < KAS_NUM_TYPES);
     return type_size_map[type];
 }
 
 /* Compare item keys lexicographically. */
 static int
-compare_items(const void *a, const void *b) {
+compare_items(const void *a, const void *b)
+{
     const kaitem_t *ia = (const kaitem_t *) a;
     const kaitem_t *ib = (const kaitem_t *) b;
-    size_t len = ia->key_len < ib->key_len? ia->key_len: ib->key_len;
+    size_t len = ia->key_len < ib->key_len ? ia->key_len : ib->key_len;
     int ret = memcmp(ia->key, ib->key, len);
     if (ret == 0) {
         ret = (ia->key_len > ib->key_len) - (ia->key_len < ib->key_len);
@@ -341,7 +341,7 @@ kastore_write_data(kastore_t *self)
 {
     int ret = 0;
     size_t j, size, offset, padding;
-    char pad[KAS_ARRAY_ALIGN] = {0, 0, 0, 0, 0, 0, 0};
+    char pad[KAS_ARRAY_ALIGN] = { 0, 0, 0, 0, 0, 0, 0 };
 
     offset = KAS_HEADER_SIZE + self->num_items * KAS_ITEM_DESCRIPTOR_SIZE;
 
@@ -405,8 +405,8 @@ kastore_read_file(kastore_t *self)
     for (j = 0; j < self->num_items; j++) {
         self->items[j].key = self->read_buffer + self->items[j].key_start - offset;
         if (read_all) {
-            self->items[j].array = self->read_buffer + self->items[j].array_start
-                - offset;
+            self->items[j].array
+                = self->read_buffer + self->items[j].array_start - offset;
         }
     }
 out:
@@ -421,13 +421,13 @@ kastore_read_item(kastore_t *self, kaitem_t *item)
     size_t size = item->array_len * type_size(item->type);
     size_t count;
 
-    item->array = malloc(size == 0? 1: size);
+    item->array = malloc(size == 0 ? 1 : size);
     if (item->array == NULL) {
         ret = KAS_ERR_NO_MEMORY;
         goto out;
     }
     if (size > 0) {
-        err = fseek(self->file, self->file_offset + (long)item->array_start, SEEK_SET);
+        err = fseek(self->file, self->file_offset + (long) item->array_start, SEEK_SET);
         if (err != 0) {
             ret = KAS_ERR_IO;
             goto out;
@@ -515,8 +515,8 @@ kastore_insert_all(kastore_t *self, kastore_t *other)
 
     for (j = 0; j < other->num_items; j++) {
         item = other->items[j];
-        ret = kastore_put(self, item.key, item.key_len, item.array, item.array_len,
-                item.type, 0);
+        ret = kastore_put(
+            self, item.key, item.key_len, item.array, item.array_len, item.type, 0);
         if (ret != 0) {
             goto out;
         }
@@ -573,7 +573,7 @@ kastore_open(kastore_t *self, const char *filename, const char *mode, int flags)
     }
     ret = kastore_openf(self, file, mode, flags);
     if (ret != 0) {
-        (void)fclose(file);
+        (void) fclose(file);
     } else {
         self->flags |= OWN_FILE;
         if (appending) {
@@ -646,7 +646,7 @@ kastore_close(kastore_t *self)
         }
     } else {
         kas_safe_free(self->read_buffer);
-        if (! (self->flags & KAS_READ_ALL)) {
+        if (!(self->flags & KAS_READ_ALL)) {
             /* The arrays have been individually malloced on demand. */
             if (self->items != NULL) {
                 for (j = 0; j < self->num_items; j++) {
@@ -689,8 +689,8 @@ kastore_containss(kastore_t *self, const char *key)
 }
 
 int KAS_WARN_UNUSED
-kastore_get(kastore_t *self, const char *key, size_t key_len,
-        void **array, size_t *array_len, int *type)
+kastore_get(kastore_t *self, const char *key, size_t key_len, void **array,
+    size_t *array_len, int *type)
 {
     int ret = KAS_ERR_KEY_NOT_FOUND;
     kaitem_t search;
@@ -707,8 +707,8 @@ kastore_get(kastore_t *self, const char *key, size_t key_len,
         goto out;
     }
     memcpy(search.key, key, key_len);
-    item = bsearch(&search, self->items, self->num_items, sizeof(kaitem_t),
-            compare_items);
+    item = bsearch(
+        &search, self->items, self->num_items, sizeof(kaitem_t), compare_items);
     if (item == NULL) {
         goto out;
     }
@@ -728,13 +728,15 @@ out:
 }
 
 int KAS_WARN_UNUSED
-kastore_gets(kastore_t *self, const char *key, void **array, size_t *array_len, int *type)
+kastore_gets(
+    kastore_t *self, const char *key, void **array, size_t *array_len, int *type)
 {
     return kastore_get(self, key, strlen(key), array, array_len, type);
 }
 
 static int KAS_WARN_UNUSED
-kastore_gets_type(kastore_t *self, const char *key, void **array, size_t *array_len, int type)
+kastore_gets_type(
+    kastore_t *self, const char *key, void **array, size_t *array_len, int type)
 {
     int loaded_type;
     int ret;
@@ -770,7 +772,8 @@ kastore_gets_int16(kastore_t *self, const char *key, int16_t **array, size_t *ar
 }
 
 int KAS_WARN_UNUSED
-kastore_gets_uint16(kastore_t *self, const char *key, uint16_t **array, size_t *array_len)
+kastore_gets_uint16(
+    kastore_t *self, const char *key, uint16_t **array, size_t *array_len)
 {
     return kastore_gets_type(self, key, (void **) array, array_len, KAS_UINT16);
 }
@@ -782,7 +785,8 @@ kastore_gets_int32(kastore_t *self, const char *key, int32_t **array, size_t *ar
 }
 
 int KAS_WARN_UNUSED
-kastore_gets_uint32(kastore_t *self, const char *key, uint32_t **array, size_t *array_len)
+kastore_gets_uint32(
+    kastore_t *self, const char *key, uint32_t **array, size_t *array_len)
 {
     return kastore_gets_type(self, key, (void **) array, array_len, KAS_UINT32);
 }
@@ -794,7 +798,8 @@ kastore_gets_int64(kastore_t *self, const char *key, int64_t **array, size_t *ar
 }
 
 int KAS_WARN_UNUSED
-kastore_gets_uint64(kastore_t *self, const char *key, uint64_t **array, size_t *array_len)
+kastore_gets_uint64(
+    kastore_t *self, const char *key, uint64_t **array, size_t *array_len)
 {
     return kastore_gets_type(self, key, (void **) array, array_len, KAS_UINT64);
 }
@@ -812,8 +817,8 @@ kastore_gets_float64(kastore_t *self, const char *key, double **array, size_t *a
 }
 
 int KAS_WARN_UNUSED
-kastore_put(kastore_t *self, const char *key, size_t key_len,
-       const void *array, size_t array_len, int type, int flags)
+kastore_put(kastore_t *self, const char *key, size_t key_len, const void *array,
+    size_t array_len, int type, int flags)
 {
     int ret;
     size_t array_size;
@@ -824,7 +829,7 @@ kastore_put(kastore_t *self, const char *key, size_t key_len,
         goto out;
     }
     array_size = type_size(type) * array_len;
-    array_copy = malloc(array_size == 0? 1: array_size);
+    array_copy = malloc(array_size == 0 ? 1 : array_size);
     if (array_copy == NULL) {
         ret = KAS_ERR_NO_MEMORY;
         goto out;
@@ -842,8 +847,8 @@ out:
 }
 
 int KAS_WARN_UNUSED
-kastore_oput(kastore_t *self, const char *key, size_t key_len,
-       void *array, size_t array_len, int type, int KAS_UNUSED(flags))
+kastore_oput(kastore_t *self, const char *key, size_t key_len, void *array,
+    size_t array_len, int type, int KAS_UNUSED(flags))
 {
     int ret = 0;
     kaitem_t *new_item;
@@ -906,156 +911,155 @@ out:
 }
 
 int KAS_WARN_UNUSED
-kastore_puts(kastore_t *self, const char *key,
-       const void *array, size_t array_len, int type, int flags)
+kastore_puts(kastore_t *self, const char *key, const void *array, size_t array_len,
+    int type, int flags)
 {
     return kastore_put(self, key, strlen(key), array, array_len, type, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_puts_int8(kastore_t *self, const char *key, const int8_t *array, size_t array_len,
-        int flags)
+kastore_puts_int8(
+    kastore_t *self, const char *key, const int8_t *array, size_t array_len, int flags)
 {
     return kastore_puts(self, key, (const void *) array, array_len, KAS_INT8, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_puts_uint8(kastore_t *self, const char *key, const uint8_t *array, size_t array_len,
-        int flags)
+kastore_puts_uint8(
+    kastore_t *self, const char *key, const uint8_t *array, size_t array_len, int flags)
 {
     return kastore_puts(self, key, (const void *) array, array_len, KAS_UINT8, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_puts_int16(kastore_t *self, const char *key, const int16_t *array, size_t array_len,
-        int flags)
+kastore_puts_int16(
+    kastore_t *self, const char *key, const int16_t *array, size_t array_len, int flags)
 {
     return kastore_puts(self, key, (const void *) array, array_len, KAS_INT16, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_puts_uint16(kastore_t *self, const char *key, const uint16_t *array, size_t array_len,
-        int flags)
+kastore_puts_uint16(
+    kastore_t *self, const char *key, const uint16_t *array, size_t array_len, int flags)
 {
     return kastore_puts(self, key, (const void *) array, array_len, KAS_UINT16, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_puts_int32(kastore_t *self, const char *key, const int32_t *array, size_t array_len,
-        int flags)
+kastore_puts_int32(
+    kastore_t *self, const char *key, const int32_t *array, size_t array_len, int flags)
 {
     return kastore_puts(self, key, (const void *) array, array_len, KAS_INT32, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_puts_uint32(kastore_t *self, const char *key, const uint32_t *array, size_t array_len,
-        int flags)
+kastore_puts_uint32(
+    kastore_t *self, const char *key, const uint32_t *array, size_t array_len, int flags)
 {
     return kastore_puts(self, key, (const void *) array, array_len, KAS_UINT32, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_puts_int64(kastore_t *self, const char *key, const int64_t *array, size_t array_len,
-        int flags)
+kastore_puts_int64(
+    kastore_t *self, const char *key, const int64_t *array, size_t array_len, int flags)
 {
     return kastore_puts(self, key, (const void *) array, array_len, KAS_INT64, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_puts_uint64(kastore_t *self, const char *key, const uint64_t *array, size_t array_len,
-        int flags)
+kastore_puts_uint64(
+    kastore_t *self, const char *key, const uint64_t *array, size_t array_len, int flags)
 {
     return kastore_puts(self, key, (const void *) array, array_len, KAS_UINT64, flags);
 }
 
-
 int KAS_WARN_UNUSED
-kastore_puts_float32(kastore_t *self, const char *key, const float *array, size_t array_len,
-        int flags)
+kastore_puts_float32(
+    kastore_t *self, const char *key, const float *array, size_t array_len, int flags)
 {
     return kastore_puts(self, key, (const void *) array, array_len, KAS_FLOAT32, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_puts_float64(kastore_t *self, const char *key, const double *array, size_t array_len,
-        int flags)
+kastore_puts_float64(
+    kastore_t *self, const char *key, const double *array, size_t array_len, int flags)
 {
     return kastore_puts(self, key, (const void *) array, array_len, KAS_FLOAT64, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_oputs(kastore_t *self, const char *key,
-       void *array, size_t array_len, int type, int flags)
+kastore_oputs(
+    kastore_t *self, const char *key, void *array, size_t array_len, int type, int flags)
 {
     return kastore_oput(self, key, strlen(key), array, array_len, type, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_oputs_int8(kastore_t *self, const char *key, int8_t *array, size_t array_len,
-        int flags)
+kastore_oputs_int8(
+    kastore_t *self, const char *key, int8_t *array, size_t array_len, int flags)
 {
     return kastore_oputs(self, key, (void *) array, array_len, KAS_INT8, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_oputs_uint8(kastore_t *self, const char *key, uint8_t *array, size_t array_len,
-        int flags)
+kastore_oputs_uint8(
+    kastore_t *self, const char *key, uint8_t *array, size_t array_len, int flags)
 {
     return kastore_oputs(self, key, (void *) array, array_len, KAS_UINT8, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_oputs_int16(kastore_t *self, const char *key, int16_t *array, size_t array_len,
-        int flags)
+kastore_oputs_int16(
+    kastore_t *self, const char *key, int16_t *array, size_t array_len, int flags)
 {
     return kastore_oputs(self, key, (void *) array, array_len, KAS_INT16, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_oputs_uint16(kastore_t *self, const char *key, uint16_t *array, size_t array_len,
-        int flags)
+kastore_oputs_uint16(
+    kastore_t *self, const char *key, uint16_t *array, size_t array_len, int flags)
 {
     return kastore_oputs(self, key, (void *) array, array_len, KAS_UINT16, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_oputs_int32(kastore_t *self, const char *key, int32_t *array, size_t array_len,
-        int flags)
+kastore_oputs_int32(
+    kastore_t *self, const char *key, int32_t *array, size_t array_len, int flags)
 {
     return kastore_oputs(self, key, (void *) array, array_len, KAS_INT32, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_oputs_uint32(kastore_t *self, const char *key, uint32_t *array, size_t array_len,
-        int flags)
+kastore_oputs_uint32(
+    kastore_t *self, const char *key, uint32_t *array, size_t array_len, int flags)
 {
     return kastore_oputs(self, key, (void *) array, array_len, KAS_UINT32, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_oputs_int64(kastore_t *self, const char *key, int64_t *array, size_t array_len,
-        int flags)
+kastore_oputs_int64(
+    kastore_t *self, const char *key, int64_t *array, size_t array_len, int flags)
 {
     return kastore_oputs(self, key, (void *) array, array_len, KAS_INT64, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_oputs_uint64(kastore_t *self, const char *key, uint64_t *array, size_t array_len,
-        int flags)
+kastore_oputs_uint64(
+    kastore_t *self, const char *key, uint64_t *array, size_t array_len, int flags)
 {
     return kastore_oputs(self, key, (void *) array, array_len, KAS_UINT64, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_oputs_float32(kastore_t *self, const char *key, float *array, size_t array_len,
-        int flags)
+kastore_oputs_float32(
+    kastore_t *self, const char *key, float *array, size_t array_len, int flags)
 {
     return kastore_oputs(self, key, (void *) array, array_len, KAS_FLOAT32, flags);
 }
 
 int KAS_WARN_UNUSED
-kastore_oputs_float64(kastore_t *self, const char *key, double *array, size_t array_len,
-        int flags)
+kastore_oputs_float64(
+    kastore_t *self, const char *key, double *array, size_t array_len, int flags)
 {
     return kastore_oputs(self, key, (void *) array, array_len, KAS_FLOAT64, flags);
 }
@@ -1073,17 +1077,17 @@ kastore_print_state(kastore_t *self, FILE *out)
     fprintf(out, "flags = %d\n", self->flags);
     fprintf(out, "num_items = %zu\n", self->num_items);
     fprintf(out, "file_size = %zu\n", self->file_size);
-    fprintf(out, "own_file  = %d\n", !! (self->flags & OWN_FILE));
+    fprintf(out, "own_file  = %d\n", !!(self->flags & OWN_FILE));
     fprintf(out, "file = '%p'\n", (void *) self->file);
     fprintf(out, "============================\n");
     for (j = 0; j < self->num_items; j++) {
         item = self->items + j;
-        fprintf(out, "%.*s: type=%d, key_start=%zu, key_len=%zu, key=%p, "
-                "array_start=%zu, array_len=%zu, array=%p\n",
-                (int) item->key_len, item->key, item->type, item->key_start, item->key_len,
-                (void *) item->key, item->array_start, item->array_len,
-                (void *) item->array);
-
+        fprintf(out,
+            "%.*s: type=%d, key_start=%zu, key_len=%zu, key=%p, "
+            "array_start=%zu, array_len=%zu, array=%p\n",
+            (int) item->key_len, item->key, item->type, item->key_start, item->key_len,
+            (void *) item->key, item->array_start, item->array_len,
+            (void *) item->array);
     }
     fprintf(out, "============================\n");
 }

--- a/c/kastore.h
+++ b/c/kastore.h
@@ -12,11 +12,11 @@ extern "C" {
 #endif
 
 #ifdef __GNUC__
-    #define KAS_WARN_UNUSED __attribute__ ((warn_unused_result))
-    #define KAS_UNUSED(x) KAS_UNUSED_ ## x __attribute__((__unused__))
+#define KAS_WARN_UNUSED __attribute__((warn_unused_result))
+#define KAS_UNUSED(x) KAS_UNUSED_##x __attribute__((__unused__))
 #else
-    #define KAS_WARN_UNUSED
-    #define KAS_UNUSED(x) KAS_UNUSED_ ## x
+#define KAS_WARN_UNUSED
+#define KAS_UNUSED(x) KAS_UNUSED_##x
 #endif
 
 #include <stdbool.h>
@@ -30,6 +30,7 @@ extern "C" {
 @defgroup ERROR_GROUP Error return values.
 @{
 */
+// clang-format off
 /**
 Generic error thrown when no other message can be generated.
 */
@@ -161,6 +162,7 @@ to the API or ABI are introduced, i.e., internal refactors of bugfixes.
 #define KAS_ITEM_DESCRIPTOR_SIZE    64
 #define KAS_MAGIC                   "\211KAS\r\n\032\n"
 #define KAS_ARRAY_ALIGN             8
+// clang-format on
 
 typedef struct {
     int type;
@@ -313,7 +315,6 @@ the array in the specified destination pointers.
 */
 int kastore_containss(kastore_t *self, const char *key);
 
-
 /**
 @brief Get the array for the specified key.
 
@@ -340,8 +341,8 @@ in the array.
 @param type The destination pointer for the type code of the array.
 @return Return 0 on success or a negative value on failure.
 */
-int kastore_get(kastore_t *self, const char *key, size_t key_len,
-        void **array, size_t *array_len, int *type);
+int kastore_get(kastore_t *self, const char *key, size_t key_len, void **array,
+    size_t *array_len, int *type);
 
 /**
 @brief Get the array for the specified NULL-terminated key.
@@ -358,24 +359,34 @@ in the array.
 @param type The destination pointer for the type code of the array.
 @return Return 0 on success or a negative value on failure.
 */
-int kastore_gets(kastore_t *self, const char *key, void **array,
-        size_t *array_len, int *type);
+int kastore_gets(
+    kastore_t *self, const char *key, void **array, size_t *array_len, int *type);
 
 /**
 @defgroup TYPED_GETS_GROUP Typed get functions.
 @{
 */
 
-int kastore_gets_int8(kastore_t *self, const char *key, int8_t **array, size_t *array_len);
-int kastore_gets_uint8(kastore_t *self, const char *key, uint8_t **array, size_t *array_len);
-int kastore_gets_int16(kastore_t *self, const char *key, int16_t **array, size_t *array_len);
-int kastore_gets_uint16(kastore_t *self, const char *key, uint16_t **array, size_t *array_len);
-int kastore_gets_int32(kastore_t *self, const char *key, int32_t **array, size_t *array_len);
-int kastore_gets_uint32(kastore_t *self, const char *key, uint32_t **array, size_t *array_len);
-int kastore_gets_int64(kastore_t *self, const char *key, int64_t **array, size_t *array_len);
-int kastore_gets_uint64(kastore_t *self, const char *key, uint64_t **array, size_t *array_len);
-int kastore_gets_float32(kastore_t *self, const char *key, float **array, size_t *array_len);
-int kastore_gets_float64(kastore_t *self, const char *key, double **array, size_t *array_len);
+int kastore_gets_int8(
+    kastore_t *self, const char *key, int8_t **array, size_t *array_len);
+int kastore_gets_uint8(
+    kastore_t *self, const char *key, uint8_t **array, size_t *array_len);
+int kastore_gets_int16(
+    kastore_t *self, const char *key, int16_t **array, size_t *array_len);
+int kastore_gets_uint16(
+    kastore_t *self, const char *key, uint16_t **array, size_t *array_len);
+int kastore_gets_int32(
+    kastore_t *self, const char *key, int32_t **array, size_t *array_len);
+int kastore_gets_uint32(
+    kastore_t *self, const char *key, uint32_t **array, size_t *array_len);
+int kastore_gets_int64(
+    kastore_t *self, const char *key, int64_t **array, size_t *array_len);
+int kastore_gets_uint64(
+    kastore_t *self, const char *key, uint64_t **array, size_t *array_len);
+int kastore_gets_float32(
+    kastore_t *self, const char *key, float **array, size_t *array_len);
+int kastore_gets_float64(
+    kastore_t *self, const char *key, double **array, size_t *array_len);
 
 /** @} */
 
@@ -402,8 +413,8 @@ strings, it is usually more convenient to use the :ref:`typed variants
 @param flags The insertion flags. Currently unused.
 @return Return 0 on success or a negative value on failure.
 */
-int kastore_put(kastore_t *self, const char *key, size_t key_len,
-        const void *array, size_t array_len, int type, int flags);
+int kastore_put(kastore_t *self, const char *key, size_t key_len, const void *array,
+    size_t array_len, int type, int flags);
 /**
 @brief Insert the specified NULL terminated key and array pair into the store.
 
@@ -420,33 +431,33 @@ As for :c:func:`kastore_put` except the key must be NULL-terminated C string.
 @return Return 0 on success or a negative value on failure.
 */
 int kastore_puts(kastore_t *self, const char *key, const void *array, size_t array_len,
-        int type, int flags);
+    int type, int flags);
 
 /**
  @defgroup TYPED_PUTS_GROUP Typed put functions.
  @{
  */
 
-int kastore_puts_int8(kastore_t *self, const char *key, const int8_t *array,
-        size_t array_len, int flags);
-int kastore_puts_uint8(kastore_t *self, const char *key, const uint8_t *array,
-        size_t array_len, int flags);
-int kastore_puts_int16(kastore_t *self, const char *key, const int16_t *array,
-        size_t array_len, int flags);
+int kastore_puts_int8(
+    kastore_t *self, const char *key, const int8_t *array, size_t array_len, int flags);
+int kastore_puts_uint8(
+    kastore_t *self, const char *key, const uint8_t *array, size_t array_len, int flags);
+int kastore_puts_int16(
+    kastore_t *self, const char *key, const int16_t *array, size_t array_len, int flags);
 int kastore_puts_uint16(kastore_t *self, const char *key, const uint16_t *array,
-        size_t array_len, int flags);
-int kastore_puts_int32(kastore_t *self, const char *key, const int32_t *array,
-        size_t array_len, int flags);
+    size_t array_len, int flags);
+int kastore_puts_int32(
+    kastore_t *self, const char *key, const int32_t *array, size_t array_len, int flags);
 int kastore_puts_uint32(kastore_t *self, const char *key, const uint32_t *array,
-        size_t array_len, int flags);
-int kastore_puts_int64(kastore_t *self, const char *key, const int64_t *array,
-        size_t array_len, int flags);
+    size_t array_len, int flags);
+int kastore_puts_int64(
+    kastore_t *self, const char *key, const int64_t *array, size_t array_len, int flags);
 int kastore_puts_uint64(kastore_t *self, const char *key, const uint64_t *array,
-        size_t array_len, int flags);
-int kastore_puts_float32(kastore_t *self, const char *key, const float *array,
-        size_t array_len, int flags);
-int kastore_puts_float64(kastore_t *self, const char *key, const double *array,
-        size_t array_len, int flags);
+    size_t array_len, int flags);
+int kastore_puts_float32(
+    kastore_t *self, const char *key, const float *array, size_t array_len, int flags);
+int kastore_puts_float64(
+    kastore_t *self, const char *key, const double *array, size_t array_len, int flags);
 
 /** @} */
 
@@ -475,8 +486,8 @@ function are identical to :c:func:`kastore_put`.
 @param flags The insertion flags. Currently unused.
 @return Return 0 on success or a negative value on failure.
 */
-int kastore_oput(kastore_t *self, const char *key, size_t key_len,
-        void *array, size_t array_len, int type, int flags);
+int kastore_oput(kastore_t *self, const char *key, size_t key_len, void *array,
+    size_t array_len, int type, int flags);
 /**
 @brief Insert the specified NULL terminated key and array pair into the store,
 transferring ownership of the malloced array buffer to the store (own-put).
@@ -494,37 +505,35 @@ As for :c:func:`kastore_oput` except the key must be NULL-terminated C string.
 @return Return 0 on success or a negative value on failure.
 */
 int kastore_oputs(kastore_t *self, const char *key, void *array, size_t array_len,
-        int type, int flags);
+    int type, int flags);
 
 /**
  @defgroup TYPED_OPUTS_GROUP Typed own-and-put functions.
  @{
  */
 
-int kastore_oputs_int8(kastore_t *self, const char *key, int8_t *array,
-        size_t array_len, int flags);
-int kastore_oputs_uint8(kastore_t *self, const char *key, uint8_t *array,
-        size_t array_len, int flags);
-int kastore_oputs_int16(kastore_t *self, const char *key, int16_t *array,
-        size_t array_len, int flags);
-int kastore_oputs_uint16(kastore_t *self, const char *key, uint16_t *array,
-        size_t array_len, int flags);
-int kastore_oputs_int32(kastore_t *self, const char *key, int32_t *array,
-        size_t array_len, int flags);
-int kastore_oputs_uint32(kastore_t *self, const char *key, uint32_t *array,
-        size_t array_len, int flags);
-int kastore_oputs_int64(kastore_t *self, const char *key, int64_t *array,
-        size_t array_len, int flags);
-int kastore_oputs_uint64(kastore_t *self, const char *key, uint64_t *array,
-        size_t array_len, int flags);
-int kastore_oputs_float32(kastore_t *self, const char *key, float *array,
-        size_t array_len, int flags);
-int kastore_oputs_float64(kastore_t *self, const char *key, double *array,
-        size_t array_len, int flags);
+int kastore_oputs_int8(
+    kastore_t *self, const char *key, int8_t *array, size_t array_len, int flags);
+int kastore_oputs_uint8(
+    kastore_t *self, const char *key, uint8_t *array, size_t array_len, int flags);
+int kastore_oputs_int16(
+    kastore_t *self, const char *key, int16_t *array, size_t array_len, int flags);
+int kastore_oputs_uint16(
+    kastore_t *self, const char *key, uint16_t *array, size_t array_len, int flags);
+int kastore_oputs_int32(
+    kastore_t *self, const char *key, int32_t *array, size_t array_len, int flags);
+int kastore_oputs_uint32(
+    kastore_t *self, const char *key, uint32_t *array, size_t array_len, int flags);
+int kastore_oputs_int64(
+    kastore_t *self, const char *key, int64_t *array, size_t array_len, int flags);
+int kastore_oputs_uint64(
+    kastore_t *self, const char *key, uint64_t *array, size_t array_len, int flags);
+int kastore_oputs_float32(
+    kastore_t *self, const char *key, float *array, size_t array_len, int flags);
+int kastore_oputs_float64(
+    kastore_t *self, const char *key, double *array, size_t array_len, int flags);
 
 /** @} */
-
-
 
 void kastore_print_state(kastore_t *self, FILE *out);
 
@@ -547,13 +556,13 @@ scheme here also takes into account ABI compatability.
 */
 kas_version_t kas_version(void);
 
-#define kas_safe_free(pointer) \
-do {\
-    if (pointer != NULL) {\
-        free(pointer);\
-        pointer = NULL;\
-    }\
-} while (0)
+#define kas_safe_free(pointer)                                                          \
+    do {                                                                                \
+        if (pointer != NULL) {                                                          \
+            free(pointer);                                                              \
+            pointer = NULL;                                                             \
+        }                                                                               \
+    } while (0)
 
 #ifdef __cplusplus
 }

--- a/c/malloc_tests.c
+++ b/c/malloc_tests.c
@@ -10,7 +10,7 @@
 #include "kastore.h"
 #include <CUnit/Basic.h>
 
-char * _tmp_file_name;
+char *_tmp_file_name;
 
 /* Wrappers used to check for correct error handling. Must be linked with the
  * link option, e.g., -Wl,--wrap=malloc. See 'ld' manpage for details.
@@ -62,7 +62,7 @@ test_write(void)
 {
     kastore_t store;
     int ret = 0;
-    int32_t array[] = {1, 2, 3, 4};
+    int32_t array[] = { 1, 2, 3, 4 };
     bool done;
 
     /* Make sure the failing malloc setup works first */
@@ -78,7 +78,7 @@ test_write(void)
     /* keep increasing fail_at until we pass. This should catch all possible
      * places at which we can fail. */
     done = false;
-    while (! done) {
+    while (!done) {
         ret = kastore_open(&store, _tmp_file_name, "w", 0);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
         _malloc_count = 0;
@@ -101,7 +101,7 @@ test_append(void)
 {
     kastore_t store;
     int ret = 0;
-    int32_t array[] = {1, 2, 3, 4};
+    int32_t array[] = { 1, 2, 3, 4 };
     bool done;
 
     ret = kastore_open(&store, _tmp_file_name, "w", 0);
@@ -115,7 +115,7 @@ test_append(void)
      * places at which we can fail. */
     _malloc_fail_at = 0;
     done = false;
-    while (! done) {
+    while (!done) {
         _malloc_count = 0;
         ret = kastore_open(&store, _tmp_file_name, "a", 0);
         if (ret == 0) {
@@ -132,7 +132,6 @@ test_append(void)
     _malloc_fail_at = -1;
 }
 
-
 static void
 test_open_read(void)
 {
@@ -141,7 +140,7 @@ test_open_read(void)
     const char *filename = "test-data/v1/all_types_1_elements.kas";
     bool done;
     size_t f;
-    int flags[] = {0, KAS_READ_ALL};
+    int flags[] = { 0, KAS_READ_ALL };
 
     /* Make sure the failing malloc setup works first */
     _malloc_fail_at = 0;
@@ -156,7 +155,7 @@ test_open_read(void)
     for (f = 0; f < sizeof(flags) / sizeof(*flags); f++) {
         _malloc_fail_at = 0;
         done = false;
-        while (! done) {
+        while (!done) {
             _malloc_count = 0;
             ret = kastore_open(&store, filename, "r", flags[f]);
             if (ret == 0) {
@@ -199,7 +198,7 @@ test_read(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     _malloc_fail_at = 0;
     done = false;
-    while (! done) {
+    while (!done) {
         _malloc_count = 0;
         ret = kastore_gets_int8(&store, "int8", &array, &size);
         if (ret == 0) {
@@ -256,8 +255,7 @@ kastore_suite_cleanup(void)
 static void
 handle_cunit_error(void)
 {
-    fprintf(stderr, "CUnit error occured: %d: %s\n",
-            CU_get_error(), CU_get_error_msg());
+    fprintf(stderr, "CUnit error occured: %d: %s\n", CU_get_error(), CU_get_error_msg());
     exit(EXIT_FAILURE);
 }
 
@@ -268,22 +266,20 @@ main(int argc, char **argv)
     CU_pTest test;
     CU_pSuite suite;
     CU_TestInfo tests[] = {
-        {"test_write", test_write},
-        {"test_append", test_append},
-        {"test_open_read", test_open_read},
-        {"test_read", test_read},
+        { "test_write", test_write },
+        { "test_append", test_append },
+        { "test_open_read", test_open_read },
+        { "test_read", test_read },
         CU_TEST_INFO_NULL,
     };
 
     /* We use initialisers here as the struct definitions change between
      * versions of CUnit */
     CU_SuiteInfo suites[] = {
-        {
-            .pName = "kastore",
+        { .pName = "kastore",
             .pInitFunc = kastore_suite_init,
             .pCleanupFunc = kastore_suite_cleanup,
-            .pTests = tests
-        },
+            .pTests = tests },
         CU_SUITE_INFO_NULL,
     };
     if (CUE_SUCCESS != CU_initialize_registry()) {

--- a/c/tests.c
+++ b/c/tests.c
@@ -9,9 +9,8 @@
 
 #include <CUnit/Basic.h>
 
-char * _tmp_file_name;
-FILE * _devnull;
-
+char *_tmp_file_name;
+FILE *_devnull;
 
 static void
 write_example_file(char *filename)
@@ -52,7 +51,7 @@ test_bad_open_flags(void)
 {
     int ret;
     kastore_t store;
-    const int bad_flags[] = {2, 3, 1<<31, -1};
+    const int bad_flags[] = { 2, 3, 1 << 31, -1 };
     size_t j;
 
     for (j = 0; j < sizeof(bad_flags) / sizeof(*bad_flags); j++) {
@@ -73,7 +72,7 @@ test_bad_open_mode(void)
 {
     int ret;
     kastore_t store;
-    const char *bad_modes[] = {"", "R", "W", "read", "rw", "write"};
+    const char *bad_modes[] = { "", "R", "W", "read", "rw", "write" };
     size_t j;
 
     for (j = 0; j < sizeof(bad_modes) / sizeof(*bad_modes); j++) {
@@ -240,7 +239,7 @@ test_write_errors(void)
 {
     int ret;
     kastore_t store;
-    int64_t a[4] = {1, 2, 3, 4};
+    int64_t a[4] = { 1, 2, 3, 4 };
 
     /* Write /dev/null should be fine */
     ret = kastore_open(&store, "/dev/random", "w", 0);
@@ -258,13 +257,13 @@ test_write_errors(void)
 static void
 test_strerror(void)
 {
-    const int max_err = 100;  /* arbitrary */
+    const int max_err = 100; /* arbitrary */
     int err;
     const char *str;
 
     /* Make sure the errno=0 codepath for IO errors is exercised */
     errno = 0;
-    for (err = 1; err < max_err ; err++) {
+    for (err = 1; err < max_err; err++) {
         str = kas_strerror(-err);
         CU_ASSERT_NOT_EQUAL_FATAL(str, NULL);
         CU_ASSERT(strlen(str) > 0);
@@ -276,7 +275,7 @@ test_bad_types(void)
 {
     int ret;
     kastore_t store;
-    uint32_t array[] = {1};
+    uint32_t array[] = { 1 };
 
     ret = kastore_open(&store, _tmp_file_name, "w", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -309,11 +308,11 @@ verify_key_round_trip(const char **keys, size_t num_keys)
     int ret;
     kastore_t store;
     size_t j, m;
-    uint32_t array[] = {1};
+    uint32_t array[] = { 1 };
     uint32_t *a;
     size_t array_len;
     int type;
-    const char* modes[] = {"a", "w"};
+    const char *modes[] = { "a", "w" };
 
     for (m = 0; m < 2; m++) {
         if (m == 0) {
@@ -339,8 +338,8 @@ verify_key_round_trip(const char **keys, size_t num_keys)
 
         CU_ASSERT_EQUAL(store.num_items, num_keys);
         for (j = 0; j < num_keys; j++) {
-            ret = kastore_get(&store, keys[j], strlen(keys[j]),
-                    (void **) &a, &array_len, &type);
+            ret = kastore_get(
+                &store, keys[j], strlen(keys[j]), (void **) &a, &array_len, &type);
             CU_ASSERT_EQUAL_FATAL(ret, 0);
             CU_ASSERT_EQUAL(type, KAS_UINT32);
             CU_ASSERT_EQUAL(array_len, 1);
@@ -354,21 +353,21 @@ verify_key_round_trip(const char **keys, size_t num_keys)
 static void
 test_different_key_length(void)
 {
-    const char *keys[] = {"a", "aa", "aaa", "aaaa", "aaaaa"};
+    const char *keys[] = { "a", "aa", "aaa", "aaaa", "aaaaa" };
     verify_key_round_trip(keys, sizeof(keys) / sizeof(*keys));
 }
 
 static void
 test_different_key_length_reverse(void)
 {
-    const char *keys[] = {"aaaaaa", "aaaa", "aaa", "aa", "a"};
+    const char *keys[] = { "aaaaaa", "aaaa", "aaa", "aa", "a" };
     verify_key_round_trip(keys, sizeof(keys) / sizeof(*keys));
 }
 
 static void
 test_mixed_keys(void)
 {
-    const char *keys[] = {"x", "aabs", "pqrastuvw", "st", "12345", "67^%"};
+    const char *keys[] = { "x", "aabs", "pqrastuvw", "st", "12345", "67^%" };
     verify_key_round_trip(keys, sizeof(keys) / sizeof(*keys));
 }
 
@@ -416,7 +415,7 @@ test_duplicate_key(void)
 {
     int ret;
     kastore_t store;
-    uint32_t array[] = {1};
+    uint32_t array[] = { 1 };
 
     ret = kastore_open(&store, _tmp_file_name, "w", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -477,7 +476,7 @@ test_empty_key(void)
 {
     int ret;
     kastore_t store;
-    uint32_t array[] = {1};
+    uint32_t array[] = { 1 };
 
     ret = kastore_open(&store, _tmp_file_name, "w", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -495,7 +494,7 @@ test_put_read_mode(void)
 {
     int ret;
     kastore_t store;
-    uint32_t array[] = {1};
+    uint32_t array[] = { 1 };
 
     ret = kastore_open(&store, _tmp_file_name, "w", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -540,7 +539,7 @@ test_contains(void)
 {
     int ret;
     kastore_t store;
-    const uint32_t array[] = {1, 2, 3, 4};
+    const uint32_t array[] = { 1, 2, 3, 4 };
 
     ret = kastore_open(&store, _tmp_file_name, "w", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -569,7 +568,7 @@ test_missing_key(void)
 {
     int ret;
     kastore_t store;
-    const uint32_t array[] = {1, 2, 3, 4};
+    const uint32_t array[] = { 1, 2, 3, 4 };
     uint32_t *a;
     size_t array_len;
     int type;
@@ -606,11 +605,11 @@ test_simple_round_trip(void)
 {
     int ret;
     kastore_t store;
-    const uint32_t array[] = {1, 2, 3, 4};
+    const uint32_t array[] = { 1, 2, 3, 4 };
     uint32_t *a;
     size_t j, array_len;
     int type;
-    int flags[] = {0, 1};
+    int flags[] = { 0, 1 };
 
     ret = kastore_open(&store, _tmp_file_name, "w", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -663,11 +662,11 @@ verify_simple_file_round_trip(const char *write_mode, const char *read_mode)
     int ret;
     FILE *f;
     kastore_t store;
-    const uint32_t array[] = {1, 2, 3, 4};
+    const uint32_t array[] = { 1, 2, 3, 4 };
     uint32_t *a;
     size_t j, array_len;
     int type;
-    int flags[] = {0, 1};
+    int flags[] = { 0, 1 };
 
     f = fopen(_tmp_file_name, write_mode);
     CU_ASSERT_NOT_EQUAL_FATAL(f, NULL);
@@ -744,7 +743,7 @@ test_simple_round_trip_zero_keys(void)
     int ret;
     kastore_t store;
     size_t j;
-    int flags[] = {0, 1};
+    int flags[] = { 0, 1 };
 
     ret = kastore_open(&store, _tmp_file_name, "w", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -771,7 +770,7 @@ test_simple_round_trip_oput_buffers(void)
     uint32_t *a;
     size_t j, array_len;
     int type;
-    int flags[] = {0, 1};
+    int flags[] = { 0, 1 };
 
     CU_ASSERT_FATAL(array_a != NULL && array_b != NULL && array_c != NULL);
     array_a[0] = 1;
@@ -832,11 +831,11 @@ test_simple_round_trip_append(void)
 {
     int ret;
     kastore_t store;
-    const uint32_t array[] = {1, 2, 3, 4};
+    const uint32_t array[] = { 1, 2, 3, 4 };
     uint32_t *a;
     size_t j, array_len;
     int type;
-    int flags[] = {0, 1};
+    int flags[] = { 0, 1 };
 
     ret = kastore_open(&store, _tmp_file_name, "w", 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -1177,7 +1176,6 @@ test_round_trip_uint32(void)
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 }
 
-
 static void
 test_round_trip_int64(void)
 {
@@ -1357,7 +1355,6 @@ verify_bad_file(const char *filename, int err)
     CU_ASSERT_EQUAL_FATAL(ret, err);
     ret = kastore_close(&store);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-
 }
 
 static void
@@ -1376,19 +1373,18 @@ test_read_bad_types(void)
 static void
 test_bad_filesizes(void)
 {
-    verify_bad_file("test-data/malformed/bad_filesize_0_-1.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
-    verify_bad_file("test-data/malformed/bad_filesize_0_1.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
-    verify_bad_file("test-data/malformed/bad_filesize_0_1024.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/bad_filesize_0_-1.kas", KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file("test-data/malformed/bad_filesize_0_1.kas", KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/bad_filesize_0_1024.kas", KAS_ERR_BAD_FILE_FORMAT);
 
-    verify_bad_file("test-data/malformed/bad_filesize_10_-1.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
-    verify_bad_file("test-data/malformed/bad_filesize_10_1.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
-    verify_bad_file("test-data/malformed/bad_filesize_10_1024.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/bad_filesize_10_-1.kas", KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/bad_filesize_10_1.kas", KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/bad_filesize_10_1024.kas", KAS_ERR_BAD_FILE_FORMAT);
 }
 
 static void
@@ -1418,64 +1414,62 @@ test_truncated_file(void)
 static void
 test_key_offset_outside_file(void)
 {
-    verify_bad_file("test-data/malformed/key_offset_outside_file.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/key_offset_outside_file.kas", KAS_ERR_BAD_FILE_FORMAT);
 }
 
 static void
 test_array_offset_outside_file(void)
 {
-    verify_bad_file("test-data/malformed/array_offset_outside_file.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/array_offset_outside_file.kas", KAS_ERR_BAD_FILE_FORMAT);
 }
 
 static void
 test_key_len_outside_file(void)
 {
-    verify_bad_file("test-data/malformed/key_len_outside_file.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/key_len_outside_file.kas", KAS_ERR_BAD_FILE_FORMAT);
 }
 
 static void
 test_array_len_outside_file(void)
 {
-    verify_bad_file("test-data/malformed/array_len_outside_file.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/array_len_outside_file.kas", KAS_ERR_BAD_FILE_FORMAT);
 }
 
 static void
 test_bad_key_start(void)
 {
-    verify_bad_file("test-data/malformed/bad_key_start_-1.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
-    verify_bad_file("test-data/malformed/bad_key_start_1.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file("test-data/malformed/bad_key_start_-1.kas", KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file("test-data/malformed/bad_key_start_1.kas", KAS_ERR_BAD_FILE_FORMAT);
 }
 
 static void
 test_bad_array_start(void)
 {
-    verify_bad_file("test-data/malformed/bad_array_start_-8.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
-    verify_bad_file("test-data/malformed/bad_array_start_-1.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
-    verify_bad_file("test-data/malformed/bad_array_start_1.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
-    verify_bad_file("test-data/malformed/bad_array_start_8.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/bad_array_start_-8.kas", KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/bad_array_start_-1.kas", KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/bad_array_start_1.kas", KAS_ERR_BAD_FILE_FORMAT);
+    verify_bad_file(
+        "test-data/malformed/bad_array_start_8.kas", KAS_ERR_BAD_FILE_FORMAT);
 }
 
 static void
 test_truncated_file_correct_size(void)
 {
     verify_bad_file("test-data/malformed/truncated_file_correct_size_100.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
+        KAS_ERR_BAD_FILE_FORMAT);
     verify_bad_file("test-data/malformed/truncated_file_correct_size_128.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
+        KAS_ERR_BAD_FILE_FORMAT);
     verify_bad_file("test-data/malformed/truncated_file_correct_size_129.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
+        KAS_ERR_BAD_FILE_FORMAT);
     verify_bad_file("test-data/malformed/truncated_file_correct_size_200.kas",
-            KAS_ERR_BAD_FILE_FORMAT);
+        KAS_ERR_BAD_FILE_FORMAT);
 }
 
 static void
@@ -1484,12 +1478,10 @@ verify_all_types_n_elements(size_t n)
     int ret;
     kastore_t store;
     const char *filename_pattern = "test-data/v1/all_types_%d_elements.kas";
-    const char *keys[] = {
-        "uint8", "int8", "uint16", "int16", "uint32", "int32", "uint64",
-        "int64", "float32", "float64"};
-    const int types[] = {
-        KAS_UINT8, KAS_INT8, KAS_UINT16, KAS_INT16, KAS_UINT32, KAS_INT32,
-        KAS_UINT64, KAS_INT64, KAS_FLOAT32, KAS_FLOAT64};
+    const char *keys[] = { "uint8", "int8", "uint16", "int16", "uint32", "int32",
+        "uint64", "int64", "float32", "float64" };
+    const int types[] = { KAS_UINT8, KAS_INT8, KAS_UINT16, KAS_INT16, KAS_UINT32,
+        KAS_INT32, KAS_UINT64, KAS_INT64, KAS_FLOAT32, KAS_FLOAT64 };
     size_t j, k, array_len;
     void *a;
     int type;
@@ -1564,7 +1556,6 @@ test_library_version(void)
     CU_ASSERT_EQUAL_FATAL(version.patch, KAS_VERSION_PATCH);
 }
 
-
 /*=================================================
   Test suite management
   =================================================
@@ -1612,8 +1603,7 @@ kastore_suite_cleanup(void)
 static void
 handle_cunit_error(void)
 {
-    fprintf(stderr, "CUnit error occured: %d: %s\n",
-            CU_get_error(), CU_get_error_msg());
+    fprintf(stderr, "CUnit error occured: %d: %s\n", CU_get_error(), CU_get_error_msg());
     exit(EXIT_FAILURE);
 }
 
@@ -1624,71 +1614,69 @@ main(int argc, char **argv)
     CU_pTest test;
     CU_pSuite suite;
     CU_TestInfo tests[] = {
-        {"test_oputs_example", test_oputs_example},
-        {"test_bad_open_flags", test_bad_open_flags},
-        {"test_bad_open_mode", test_bad_open_mode},
-        {"test_openf_bad_file_read_modes", test_openf_bad_file_read_modes},
-        {"test_openf_bad_file_write_modes", test_openf_bad_file_write_modes},
-        {"test_open_io_errors", test_open_io_errors},
-        {"test_append_empty_file", test_append_empty_file},
-        {"test_write_errors", test_write_errors},
-        {"test_strerror", test_strerror},
-        {"test_empty_key", test_empty_key},
-        {"test_get_write_mode", test_get_write_mode},
-        {"test_put_read_mode", test_put_read_mode},
-        {"test_different_key_length", test_different_key_length},
-        {"test_different_key_length_reverse", test_different_key_length_reverse},
-        {"test_mixed_keys", test_mixed_keys},
-        {"test_put_copy_array", test_put_copy_array},
-        {"test_duplicate_key", test_duplicate_key},
-        {"test_duplicate_key_oput", test_duplicate_key_oput},
-        {"test_missing_key", test_missing_key},
-        {"test_contains", test_contains},
-        {"test_bad_types", test_bad_types},
-        {"test_simple_round_trip", test_simple_round_trip},
-        {"test_simple_round_trip_file_modes", test_simple_round_trip_file_modes},
-        {"test_simple_round_trip_zero_keys", test_simple_round_trip_zero_keys},
-        {"test_simple_round_trip_oput_buffers", test_simple_round_trip_oput_buffers},
-        {"test_simple_round_trip_append", test_simple_round_trip_append},
-        {"test_gets_type_errors", test_gets_type_errors},
-        {"test_round_trip_int8", test_round_trip_int8},
-        {"test_round_trip_uint8", test_round_trip_uint8},
-        {"test_round_trip_int16", test_round_trip_int16},
-        {"test_round_trip_uint16", test_round_trip_uint16},
-        {"test_round_trip_int32", test_round_trip_int32},
-        {"test_round_trip_uint32", test_round_trip_uint32},
-        {"test_round_trip_int64", test_round_trip_int64},
-        {"test_round_trip_uint64", test_round_trip_uint64},
-        {"test_round_trip_float32", test_round_trip_float32},
-        {"test_round_trip_float64", test_round_trip_float64},
-        {"test_empty_file", test_empty_file},
-        {"test_read_bad_types", test_read_bad_types},
-        {"test_bad_filesizes", test_bad_filesizes},
-        {"test_bad_magic_number", test_bad_magic_number},
-        {"test_version_0", test_version_0},
-        {"test_version_100", test_version_100},
-        {"test_truncated_file", test_truncated_file},
-        {"test_key_offset_outside_file", test_key_offset_outside_file},
-        {"test_array_offset_outside_file", test_array_offset_outside_file},
-        {"test_key_len_outside_file", test_key_len_outside_file},
-        {"test_array_len_outside_file", test_array_len_outside_file},
-        {"test_bad_key_start", test_bad_key_start},
-        {"test_bad_array_start", test_bad_array_start},
-        {"test_truncated_file_correct_size", test_truncated_file_correct_size},
-        {"test_all_types_n_elements", test_all_types_n_elements},
-        {"test_library_version", test_library_version},
+        { "test_oputs_example", test_oputs_example },
+        { "test_bad_open_flags", test_bad_open_flags },
+        { "test_bad_open_mode", test_bad_open_mode },
+        { "test_openf_bad_file_read_modes", test_openf_bad_file_read_modes },
+        { "test_openf_bad_file_write_modes", test_openf_bad_file_write_modes },
+        { "test_open_io_errors", test_open_io_errors },
+        { "test_append_empty_file", test_append_empty_file },
+        { "test_write_errors", test_write_errors },
+        { "test_strerror", test_strerror },
+        { "test_empty_key", test_empty_key },
+        { "test_get_write_mode", test_get_write_mode },
+        { "test_put_read_mode", test_put_read_mode },
+        { "test_different_key_length", test_different_key_length },
+        { "test_different_key_length_reverse", test_different_key_length_reverse },
+        { "test_mixed_keys", test_mixed_keys },
+        { "test_put_copy_array", test_put_copy_array },
+        { "test_duplicate_key", test_duplicate_key },
+        { "test_duplicate_key_oput", test_duplicate_key_oput },
+        { "test_missing_key", test_missing_key },
+        { "test_contains", test_contains },
+        { "test_bad_types", test_bad_types },
+        { "test_simple_round_trip", test_simple_round_trip },
+        { "test_simple_round_trip_file_modes", test_simple_round_trip_file_modes },
+        { "test_simple_round_trip_zero_keys", test_simple_round_trip_zero_keys },
+        { "test_simple_round_trip_oput_buffers", test_simple_round_trip_oput_buffers },
+        { "test_simple_round_trip_append", test_simple_round_trip_append },
+        { "test_gets_type_errors", test_gets_type_errors },
+        { "test_round_trip_int8", test_round_trip_int8 },
+        { "test_round_trip_uint8", test_round_trip_uint8 },
+        { "test_round_trip_int16", test_round_trip_int16 },
+        { "test_round_trip_uint16", test_round_trip_uint16 },
+        { "test_round_trip_int32", test_round_trip_int32 },
+        { "test_round_trip_uint32", test_round_trip_uint32 },
+        { "test_round_trip_int64", test_round_trip_int64 },
+        { "test_round_trip_uint64", test_round_trip_uint64 },
+        { "test_round_trip_float32", test_round_trip_float32 },
+        { "test_round_trip_float64", test_round_trip_float64 },
+        { "test_empty_file", test_empty_file },
+        { "test_read_bad_types", test_read_bad_types },
+        { "test_bad_filesizes", test_bad_filesizes },
+        { "test_bad_magic_number", test_bad_magic_number },
+        { "test_version_0", test_version_0 },
+        { "test_version_100", test_version_100 },
+        { "test_truncated_file", test_truncated_file },
+        { "test_key_offset_outside_file", test_key_offset_outside_file },
+        { "test_array_offset_outside_file", test_array_offset_outside_file },
+        { "test_key_len_outside_file", test_key_len_outside_file },
+        { "test_array_len_outside_file", test_array_len_outside_file },
+        { "test_bad_key_start", test_bad_key_start },
+        { "test_bad_array_start", test_bad_array_start },
+        { "test_truncated_file_correct_size", test_truncated_file_correct_size },
+        { "test_all_types_n_elements", test_all_types_n_elements },
+        { "test_library_version", test_library_version },
         CU_TEST_INFO_NULL,
     };
 
     /* We use initialisers here as the struct definitions change between
      * versions of CUnit */
     CU_SuiteInfo suites[] = {
-        {
-            .pName = "kastore",
+        { .pName = "kastore",
             .pInitFunc = kastore_suite_init,
             .pCleanupFunc = kastore_suite_cleanup,
-            .pTests = tests
-        },
+            .pTests = tests },
         CU_SUITE_INFO_NULL,
     };
     if (CUE_SUCCESS != CU_initialize_registry()) {

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -36,6 +36,11 @@ upload to PyPI.
 C API
 -----
 
+When modifying the C code this will conform it to the project style::
+
+  $ sudo apt-get install clang-format
+  $ clang-format -i c/*.{h,c,cpp}
+
 If the C API has been updated, the ``KAS_VERSION_*`` macros should be set
 appropriately, ensuring that the Changelog has been updated to record the
 changes. After the commit including these changes has been merged, tag a


### PR DESCRIPTION
Fixes #104 
Not many changes, turned off formatting for the header constants.