### PR TITLE
Change internal flag value to fit into 16 bit int

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -1,4 +1,15 @@
 --------------------
+[2.0.1] - 2021-11-xx
+--------------------
+
+- Minor bug-release and maintenance update.
+
+**Bug fixes**
+
+- Fix an overflow in an internal flags value on platforms with
+  16 bit int types (:user:`jeromekelleher`, :issue:`153`, :pr:`153`).
+
+--------------------
 [2.0.0] - 2020-05-23
 --------------------
 

--- a/c/kastore.c
+++ b/c/kastore.c
@@ -9,7 +9,10 @@
 
 /* Private flag used to indicate when we have opened the file ourselves
  * and need to free it. */
-#define OWN_FILE (1 << 31)
+/* Note: we use 1<<14 to keep this flag at the end of the flag space,
+ * and this is the highest bit that can be guaranteed to fit into
+ * an int. */
+#define OWN_FILE (1 << 14)
 
 const char *
 kas_strerror(int err)


### PR DESCRIPTION
Closes #153

This ended up being the least intrusive way to fix the issue @bhaller. Ideally we'd have changed the flags field to a ``uint32_t`` so we're clear what can fit in and what won't, but this would have involved changing some public APIs. Since we're exceedingly unlikely to need more than 15 flags (since ints are only guaranteed to be 16 bit)  I think this is fine.

I think this was only really a bug on platforms with 16 bit ints, so I'm not going to worry about it. It was definitely working correctly on 64 bit linux, where ints are 4 bytes, so I see no reason to believe it didn't work elsewhere.