### PR TITLE
Add missing goto and fix tests

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -9,6 +9,10 @@
 - Fix an overflow in an internal flags value on platforms with
   16 bit int types (:user:`jeromekelleher`, :issue:`153`, :pr:`153`).
 
+- Fix a bug in which error conditions were not reported in append
+  mode if an error occured when closing the temporary file used
+  to read the data. (:user:`jeromekelleher`, :issue:`160`, :pr:`164`).
+
 --------------------
 [2.0.0] - 2020-05-23
 --------------------

--- a/c/io_tests.c
+++ b/c/io_tests.c
@@ -211,6 +211,10 @@ test_append_fclose(void)
      * places at which we can fail. */
     _fclose_fail_at = 0;
     _fclose_count = 0;
+    /* First fail is a special case, happens when closing the tmp file */
+    ret = kastore_open(&store, _tmp_file_name, "a", 0);
+    CU_ASSERT_EQUAL_FATAL(ret, KAS_ERR_IO);
+    _fclose_fail_at = 1;
     done = false;
     while (!done) {
         ret = kastore_open(&store, _tmp_file_name, "a", 0);

--- a/c/kastore.c
+++ b/c/kastore.c
@@ -562,6 +562,7 @@ kastore_open(kastore_t *self, const char *filename, const char *mode, int flags)
         tmp.file = NULL;
         if (err != 0) {
             ret = KAS_ERR_IO;
+            goto out;
         }
     }
     file = fopen(filename, file_mode);


### PR DESCRIPTION
Closes #160

This was a bug, but a vanishingly unlikely one to ever actually occur because it would have to happen when closing a read-only file.