### PR TITLE
Bump test coverage in low-level module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           name: Compile Python
           command: |
             cd python
-            CFLAGS="--coverage -Wall -Wextra -Werror -Wno-unused-parameter -Wno-cast-function-type" \
+            CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter -Wno-cast-function-type" \
               python setup.py build_ext --inplace
       - run:
           name: Run Python tests
@@ -28,6 +28,7 @@ jobs:
             cd python
             python3 -m pytest --cov=kastore  --cov-report=xml --cov-branch tests
             python3 -m codecov -F python
+
       - run:
           name: Build Python package
           command: |
@@ -42,12 +43,14 @@ jobs:
             python setup.py bdist_wheel
             pip wheel dist/*.tar.gz
             pip install dist/*.tar.gz
+
       - run:
           name: Compile C
           command: |
             # Build with coverage options
             meson c/ build-gcc -D b_coverage=true
             ninja -C build-gcc
+
       - run:
           name: Run C tests
           command: |
@@ -55,6 +58,15 @@ jobs:
             ./build-gcc/cpp_tests
             ./build-gcc/malloc_tests
             ./build-gcc/io_tests
+
+      - run:
+          name: Run Python with C coverage
+          command: |
+            cd python
+            rm -fR build
+            CFLAGS="--coverage"  python setup.py build_ext --inplace
+            python3 -m pytest tests
+
       - run:
           name: Run gcov & upload coverage.
           command: |
@@ -64,6 +76,7 @@ jobs:
               ./build-gcc/io_tests@exe/kastore.c.gcno \
               ./build-gcc/kastore@sha/kastore.c.gcno
             codecov -X gcov -F C
+
       - run:
           name: Valgrind for C tests.
           command: |

--- a/python/_kastoremodule.c
+++ b/python/_kastoremodule.c
@@ -209,6 +209,9 @@ parse_dictionary(kastore_t *store, PyObject *data)
         }
         encoded_key = PyUnicode_AsEncodedString(py_key, "utf-8", "strict");
         if (encoded_key == NULL) {
+            /* This error is very difficult/impossible to provoke because
+             * PyUnicode_Check makes sure it's unicode, and you can't make
+             * invalid unicode strings. */
             goto out;
         }
         if (PyBytes_AsStringAndSize(encoded_key, &key, &key_len) != 0) {

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -53,7 +53,7 @@ class TestBasicOperation(unittest.TestCase):
 
 @unittest.skipIf(IS_WINDOWS, "Not worth making this work on windows")
 class TestInputs(unittest.TestCase):
-    def test_bad_numeric(self):
+    def test_bad_numeric_fd(self):
         for fd in ["1", 1.0, 2.0]:
             with self.assertRaises(TypeError):
                 _kastore.dump({}, fd)
@@ -79,3 +79,14 @@ class TestInputs(unittest.TestCase):
         with open(os.devnull, "w") as f:
             with self.assertRaises(OSError):
                 _kastore.load(f)
+
+    def test_bad_load_args(self):
+        with self.assertRaises(TypeError):
+            _kastore.load(0, read_all="sdf")
+
+    def test_bad_dtype(self):
+        with open(os.devnull, "w") as f:
+            with self.assertRaises(ValueError):
+                # complex number
+                array = np.array([0], dtype="c16")
+                _kastore.dump({"a": array}, f)


### PR DESCRIPTION
This is about as much as I can hit - spent an interesting half hour trying to make a non-unicode string in Python (tip: you can't!)

If this doesn't bring us above 95% then we'll have to fiddle with the codecov config, which shouldn't be marking this as part of the Python label anyway.