### PR TITLE
Prevent `contains` from borrowing an array

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -2,6 +2,14 @@
 [2.1.1] - 2021-03-01
 --------------------
 
+- Fix bug where calling `contains` would borrow the array when `KAS_BORROWS_ARRAY` was set.
+  (:user:`benjeffery`, :pr:`189`)
+
+
+--------------------
+[2.1.1] - 2021-03-01
+--------------------
+
 - Minor bug-release and maintenance update.
 
 - Fix assertion triggered when NULL was passed along with KAS_BORROWS_ARRAY.

--- a/c/kastore.h
+++ b/c/kastore.h
@@ -157,7 +157,7 @@ to the API or ABI are introduced, i.e., the addition of a new function.
 The library patch version. Incremented when any changes not relevant to the
 to the API or ABI are introduced, i.e., internal refactors of bugfixes.
 */
-#define KAS_VERSION_PATCH   0
+#define KAS_VERSION_PATCH   1
 /** @} */
 
 #define KAS_HEADER_SIZE             64

--- a/c/tests.c
+++ b/c/tests.c
@@ -728,6 +728,10 @@ test_take_ownership(void)
             &store, _tmp_file_name, "r", flags[j] | KAS_GET_TAKES_OWNERSHIP);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
 
+        // Check that contains doesn't borrow
+        ret = kastore_containss(&store, "a");
+        CU_ASSERT_EQUAL_FATAL(ret, 1);
+
         CU_ASSERT_EQUAL(store.num_items, 4);
         ret = kastore_gets(&store, "a", (void **) &a, &array_len, &type);
         CU_ASSERT_EQUAL_FATAL(ret, 0);


### PR DESCRIPTION
When `KAS_GET_TAKES_OWNERSHIP` was specified, `contains` borrowed the array as it used `get`. This refactors to not use `get`.