### PR TITLE
Fix integer overflow in file read path

### DIFF
--- a/c/CHANGELOG.rst
+++ b/c/CHANGELOG.rst
@@ -1,4 +1,15 @@
 --------------------
+[2.1.3] - 2026-xx-xx
+--------------------
+
+- Security fix: reject malformed/crafted store files whose item descriptors
+  contain length and offset fields that overflow when bounds-checked (e.g. a
+  huge ``array_len`` whose byte size wraps past ``file_size``). Such a file
+  previously passed validation and could cause an under-allocated buffer to be
+  returned with a large reported length, leading to an out-of-bounds read in
+  the caller. Zero-length keys are also now rejected on read.
+
+--------------------
 [2.1.2] - 2026-03-03
 --------------------
 

--- a/c/kastore.c
+++ b/c/kastore.c
@@ -397,16 +397,11 @@ kastore_read_file(kastore_t *self)
 
     offset = KAS_HEADER_SIZE + self->num_items * KAS_ITEM_DESCRIPTOR_SIZE;
 
-    /* Read in up to the start of first array. This will contain all the keys. */
-    size = self->items[0].array_start;
-
-    /* The first array must start strictly after the descriptors; otherwise the
-     * file geometry is corrupt (e.g. all keys have zero length). */
-    if (size <= offset) {
-        ret = KAS_ERR_BAD_FILE_FORMAT;
-        goto out;
-    }
-    size -= offset;
+    /* Read in up to the start of first array. This will contain all the keys.
+     * kastore_read_descriptors rejects zero-length keys and validates the key
+     * and array packing, so items[0].array_start is always strictly greater
+     * than offset and the subtraction below cannot underflow. */
+    size = self->items[0].array_start - offset;
 
     self->key_read_buffer = (char *) malloc(size);
     if (self->key_read_buffer == NULL) {

--- a/c/kastore.c
+++ b/c/kastore.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <limits.h>
 
 #include "kastore.h"
 
@@ -292,12 +293,21 @@ kastore_read_descriptors(kastore_t *self)
             goto out;
         }
         self->items[j].type = (int) type;
-        if (key_start + key_len > self->file_size) {
+        if (key_len == 0) {
+            /* Keys must be non-empty, matching the write-side invariant. */
+            goto out;
+        }
+        /* The bounds checks below are written using subtraction and division so
+         * that they cannot themselves overflow on these attacker-controlled
+         * 64-bit values (e.g. key_start + key_len or array_len * type_size
+         * wrapping around past file_size). */
+        if (key_start > self->file_size || key_len > self->file_size - key_start) {
             goto out;
         }
         self->items[j].key_start = (size_t) key_start;
         self->items[j].key_len = (size_t) key_len;
-        if (array_start + array_len * type_size(type) > self->file_size) {
+        if (array_start > self->file_size
+            || array_len > (self->file_size - array_start) / type_size(type)) {
             goto out;
         }
         self->items[j].array_start = (size_t) array_start;
@@ -390,7 +400,12 @@ kastore_read_file(kastore_t *self)
     /* Read in up to the start of first array. This will contain all the keys. */
     size = self->items[0].array_start;
 
-    assert(size > offset);
+    /* The first array must start strictly after the descriptors; otherwise the
+     * file geometry is corrupt (e.g. all keys have zero length). */
+    if (size <= offset) {
+        ret = KAS_ERR_BAD_FILE_FORMAT;
+        goto out;
+    }
     size -= offset;
 
     self->key_read_buffer = (char *) malloc(size);
@@ -445,6 +460,12 @@ kastore_read_item(kastore_t *self, kaitem_t *item)
         goto out;
     }
     if (size > 0) {
+        /* array_start is a size_t but fseek takes a long, which is only 32 bits
+         * on LLP64 platforms (e.g. 64-bit Windows). Guard against truncation. */
+        if (item->array_start > (size_t) (LONG_MAX - self->file_offset)) {
+            ret = KAS_ERR_IO;
+            goto out;
+        }
         err = fseek(self->file, self->file_offset + (long) item->array_start, SEEK_SET);
         if (err != 0) {
             ret = KAS_ERR_IO;

--- a/c/tests.c
+++ b/c/tests.c
@@ -1673,6 +1673,105 @@ test_bad_array_start(void)
         test_path("malformed/bad_array_start_8.kas"), KAS_ERR_BAD_FILE_FORMAT);
 }
 
+/* Build a single-descriptor file with fully attacker-controlled header and
+ * descriptor fields, so we can exercise the bounds checking in
+ * kastore_read_descriptors directly. data_size is the number of bytes written
+ * after the header and descriptor (i.e. the key + array region on disk). */
+static void
+write_crafted_file(const char *filename, uint8_t type, uint64_t key_start,
+    uint64_t key_len, uint64_t array_start, uint64_t array_len, uint64_t file_size,
+    uint32_t num_items, size_t data_size)
+{
+    char header[KAS_HEADER_SIZE];
+    char descriptor[KAS_ITEM_DESCRIPTOR_SIZE];
+    char pad[256];
+    uint16_t version_major = KAS_FILE_VERSION_MAJOR;
+    uint16_t version_minor = KAS_FILE_VERSION_MINOR;
+    FILE *f;
+    size_t chunk;
+
+    memset(header, 0, sizeof(header));
+    memcpy(header, KAS_MAGIC, 8);
+    memcpy(header + 8, &version_major, 2);
+    memcpy(header + 10, &version_minor, 2);
+    memcpy(header + 12, &num_items, 4);
+    memcpy(header + 16, &file_size, 8);
+
+    memset(descriptor, 0, sizeof(descriptor));
+    memcpy(descriptor, &type, 1);
+    memcpy(descriptor + 8, &key_start, 8);
+    memcpy(descriptor + 16, &key_len, 8);
+    memcpy(descriptor + 24, &array_start, 8);
+    memcpy(descriptor + 32, &array_len, 8);
+
+    f = fopen(filename, "wb");
+    CU_ASSERT_FATAL(f != NULL);
+    CU_ASSERT_EQUAL_FATAL(fwrite(header, 1, sizeof(header), f), sizeof(header));
+    CU_ASSERT_EQUAL_FATAL(
+        fwrite(descriptor, 1, sizeof(descriptor), f), sizeof(descriptor));
+    memset(pad, 0, sizeof(pad));
+    while (data_size > 0) {
+        chunk = data_size < sizeof(pad) ? data_size : sizeof(pad);
+        CU_ASSERT_EQUAL_FATAL(fwrite(pad, 1, chunk, f), chunk);
+        data_size -= chunk;
+    }
+    fclose(f);
+}
+
+static void
+test_array_len_overflow(void)
+{
+    /* array_len * type_size(KAS_UINT64) == 2^61 * 8 == 2^64, which wraps to 0.
+     * On a vulnerable build this slips past the bounds check and under-allocates,
+     * while reporting a 2^61-element array. Must be rejected. */
+    uint64_t array_len = (uint64_t) 1 << 61;
+    write_crafted_file(_tmp_file_name, KAS_UINT64, 128, 8, 136, array_len, 136, 1, 8);
+    verify_bad_file(_tmp_file_name, KAS_ERR_BAD_FILE_FORMAT);
+}
+
+static void
+test_key_len_overflow(void)
+{
+    /* key_start + key_len overflows uint64 (128 + (2^64 - 1) wraps to 127). */
+    write_crafted_file(_tmp_file_name, KAS_UINT8, 128, UINT64_MAX, 136, 1, 136, 1, 8);
+    verify_bad_file(_tmp_file_name, KAS_ERR_BAD_FILE_FORMAT);
+}
+
+static void
+test_zero_key_len(void)
+{
+    /* Zero-length keys are invalid; must be rejected and must not reach the
+     * read-path assertion on the first array offset. */
+    write_crafted_file(_tmp_file_name, KAS_UINT8, 128, 0, 128, 0, 128, 1, 0);
+    verify_bad_file(_tmp_file_name, KAS_ERR_BAD_FILE_FORMAT);
+}
+
+static void
+test_crafted_file_valid_control(void)
+{
+    /* Positive control: a well-formed descriptor built by write_crafted_file
+     * opens and reads back, confirming the overflow cases above are rejected
+     * specifically because of the overflow, not some other malformation. */
+    int ret;
+    kastore_t store;
+    void *array;
+    size_t array_len;
+    int type;
+    char key[8];
+
+    memset(key, 0, sizeof(key));
+    /* key_start=128, key_len=8, array_start=136, array_len=1 uint64 -> 144 bytes */
+    write_crafted_file(_tmp_file_name, KAS_UINT64, 128, 8, 136, 1, 144, 1, 16);
+    ret = kastore_open(&store, _tmp_file_name, "r", 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = kastore_get(&store, key, sizeof(key), &array, &array_len, &type);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(array_len, 1);
+    CU_ASSERT_EQUAL_FATAL(type, KAS_UINT64);
+    ret = kastore_close(&store);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+}
+
 static void
 test_truncated_file_correct_size(void)
 {
@@ -1896,6 +1995,10 @@ main(int argc, char **argv)
         { "test_array_len_outside_file", test_array_len_outside_file },
         { "test_bad_key_start", test_bad_key_start },
         { "test_bad_array_start", test_bad_array_start },
+        { "test_array_len_overflow", test_array_len_overflow },
+        { "test_key_len_overflow", test_key_len_overflow },
+        { "test_zero_key_len", test_zero_key_len },
+        { "test_crafted_file_valid_control", test_crafted_file_valid_control },
         { "test_truncated_file_correct_size", test_truncated_file_correct_size },
         { "test_all_types_n_elements", test_all_types_n_elements },
         { "test_library_version", test_library_version },

--- a/c/tests.c
+++ b/c/tests.c
@@ -1773,6 +1773,80 @@ test_crafted_file_valid_control(void)
 }
 
 static void
+test_array_start_seek_overflow(void)
+{
+    /* A two-item file whose SECOND array starts beyond LONG_MAX. The first array
+     * starts immediately after the short key region, so the store opens in lazy
+     * mode (only the keys are read up front and the huge file_size is never
+     * backed by real data). Fetching the second key then reaches
+     * kastore_read_item, where file_offset + array_start would overflow the
+     * (long) cast used by fseek on LLP64 platforms. This must be reported as
+     * KAS_ERR_IO rather than silently seeking to a truncated offset. */
+    char header[KAS_HEADER_SIZE];
+    char descriptors[2 * KAS_ITEM_DESCRIPTOR_SIZE];
+    char keys[16];
+    uint16_t version_major = KAS_FILE_VERSION_MAJOR;
+    uint16_t version_minor = KAS_FILE_VERSION_MINOR;
+    uint32_t num_items = 2;
+    uint8_t type = KAS_UINT8;
+    /* offset = header + two descriptors = 192 */
+    uint64_t key0_start = 192, key0_len = 8;
+    uint64_t key1_start = 200, key1_len = 8;
+    uint64_t array0_start = 208;
+    uint64_t array1_start = (uint64_t) 1 << 63;        /* > LONG_MAX */
+    uint64_t array0_len = array1_start - array0_start; /* fills the gap, type uint8 */
+    uint64_t array1_len = 8;
+    uint64_t file_size = array1_start + array1_len;
+    FILE *f;
+    int ret;
+    kastore_t store;
+    void *array;
+    size_t array_len;
+    int gtype;
+    char key1[8];
+
+    memset(header, 0, sizeof(header));
+    memcpy(header, KAS_MAGIC, 8);
+    memcpy(header + 8, &version_major, 2);
+    memcpy(header + 10, &version_minor, 2);
+    memcpy(header + 12, &num_items, 4);
+    memcpy(header + 16, &file_size, 8);
+
+    memset(descriptors, 0, sizeof(descriptors));
+    memcpy(descriptors, &type, 1);
+    memcpy(descriptors + 8, &key0_start, 8);
+    memcpy(descriptors + 16, &key0_len, 8);
+    memcpy(descriptors + 24, &array0_start, 8);
+    memcpy(descriptors + 32, &array0_len, 8);
+    memcpy(descriptors + KAS_ITEM_DESCRIPTOR_SIZE, &type, 1);
+    memcpy(descriptors + KAS_ITEM_DESCRIPTOR_SIZE + 8, &key1_start, 8);
+    memcpy(descriptors + KAS_ITEM_DESCRIPTOR_SIZE + 16, &key1_len, 8);
+    memcpy(descriptors + KAS_ITEM_DESCRIPTOR_SIZE + 24, &array1_start, 8);
+    memcpy(descriptors + KAS_ITEM_DESCRIPTOR_SIZE + 32, &array1_len, 8);
+
+    /* Two 8-byte keys in ascending order, so bsearch can locate the second. */
+    memset(keys, 0x01, 8);
+    memset(keys + 8, 0x02, 8);
+
+    f = fopen(_tmp_file_name, "wb");
+    CU_ASSERT_FATAL(f != NULL);
+    CU_ASSERT_EQUAL_FATAL(fwrite(header, 1, sizeof(header), f), sizeof(header));
+    CU_ASSERT_EQUAL_FATAL(
+        fwrite(descriptors, 1, sizeof(descriptors), f), sizeof(descriptors));
+    CU_ASSERT_EQUAL_FATAL(fwrite(keys, 1, sizeof(keys), f), sizeof(keys));
+    fclose(f);
+
+    /* Lazy open succeeds: only the key region is read. */
+    ret = kastore_open(&store, _tmp_file_name, "r", 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    memset(key1, 0x02, sizeof(key1));
+    ret = kastore_get(&store, key1, sizeof(key1), &array, &array_len, &gtype);
+    CU_ASSERT_EQUAL_FATAL(ret, KAS_ERR_IO);
+    ret = kastore_close(&store);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+}
+
+static void
 test_truncated_file_correct_size(void)
 {
     verify_bad_file(test_path("malformed/truncated_file_correct_size_100.kas"),
@@ -1999,6 +2073,7 @@ main(int argc, char **argv)
         { "test_key_len_overflow", test_key_len_overflow },
         { "test_zero_key_len", test_zero_key_len },
         { "test_crafted_file_valid_control", test_crafted_file_valid_control },
+        { "test_array_start_seek_overflow", test_array_start_seek_overflow },
         { "test_truncated_file_correct_size", test_truncated_file_correct_size },
         { "test_all_types_n_elements", test_all_types_n_elements },
         { "test_library_version", test_library_version },

--- a/python/CHANGELOG.rst
+++ b/python/CHANGELOG.rst
@@ -2,7 +2,12 @@
 [0.3.6] - 2026-xx-xx
 --------------------
 
-In development
+- Security fix (C library): reject malformed/crafted store files whose item
+  descriptors contain length and offset fields that overflow when
+  bounds-checked (e.g. a huge ``array_len`` whose byte size wraps past the
+  recorded file size). Such a file previously passed validation and could
+  cause an under-allocated buffer to be returned with a large reported length,
+  leading to an out-of-bounds read when loading the array.
 
 --------------------
 [0.3.5] - 2026-03-03


### PR DESCRIPTION
Harden kastore_read_descriptors against crafted files: the bounds checks key_start + key_len and array_start + array_len * type_size were computed in 64-bit arithmetic on untrusted values and could wrap around past file_size. A file declaring e.g. array_len = 2^61 of KAS_UINT64 passed all validation (including the structural checks, which accumulate the same wrapping product) but caused kastore_read_item to under-allocate while reporting a huge array_len, leading to an out-of-bounds read in the caller. The checks are now written with subtraction and division so they cannot overflow.

Also reject zero-length keys on read (matching the write-side invariant) and replace the reachable assert(size > offset) in kastore_read_file with a KAS_ERR_BAD_FILE_FORMAT return, and guard the (long) cast of array_start in kastore_read_item's fseek against truncation on LLP64 platforms.

Add tests covering the array_len and key_len overflow cases, zero-length keys, and a positive control.

Closes #251 